### PR TITLE
More StaticSymbol constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -382,6 +382,12 @@ struct StaticSymbol{s}
     StaticSymbol(s::Symbol) = new{s}()
 end
 
+StaticSymbol(x::StaticSymbol) = x
+StaticSymbol(x::StaticSymbol, args::Vararg{StaticSymbol}) = _cat_syms((x, args...))
+@generated function _cat_syms(::T) where {T<:Tuple{Vararg{StaticSymbol}}}
+    :(StaticSymbol{$(QuoteNode(Symbol([s_i.parameters[1] for s_i in T.parameters]...)))}())
+end
+
 Base.Symbol(::StaticSymbol{s}) where {s} = s::Symbol
 
 Base.show(io::IO, ::StaticSymbol{s}) where {s} = print(io, "static(:$s)")

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -380,13 +380,15 @@ A statically typed `Symbol`.
 struct StaticSymbol{s}
     StaticSymbol{s}() where {s} = new{s::Symbol}()
     StaticSymbol(s::Symbol) = new{s}()
+    StaticSymbol(x::StaticSymbol) = x
+    StaticSymbol(x) = StaticSymbol(Symbol(x))
 end
-
-StaticSymbol(x::StaticSymbol) = x
-StaticSymbol(x::StaticSymbol, args::Vararg{StaticSymbol}) = _cat_syms((x, args...))
-@generated function _cat_syms(::T) where {T<:Tuple{Vararg{StaticSymbol}}}
-    :(StaticSymbol{$(QuoteNode(Symbol([s_i.parameters[1] for s_i in T.parameters]...)))}())
+StaticSymbol(x, y) = StaticSymbol(Symbol(x, y))
+StaticSymbol(x::StaticSymbol, y::StaticSymbol) = _cat_syms(x, y)
+@generated function _cat_syms(::StaticSymbol{x}, ::StaticSymbol{y}) where {x,y}
+    return :(StaticSymbol{$(QuoteNode(Symbol(x, y)))}())
 end
+StaticSymbol(x, y, z...) = StaticSymbol(StaticSymbol(x, y), z...)
 
 Base.Symbol(::StaticSymbol{s}) where {s} = s::Symbol
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,6 +183,13 @@ using Test
         @test @inferred(promote_rule(Bool, True)) <: Bool
     end
 
+    @testset "StaticSymbol" begin
+        x = static(:x)
+        y = static(:y)
+        @test @inferred(StaticSymbol(x)) === x
+        @test @inferred(StaticSymbol(x, y)) === static(:xy)
+    end
+
     @testset "static" begin
         @test static(1) === StaticInt(1)
         @test static(true) === True()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,10 +184,14 @@ using Test
     end
 
     @testset "StaticSymbol" begin
-        x = static(:x)
-        y = static(:y)
+        x = StaticSymbol(:x)
+        y = StaticSymbol("y")
+        z = StaticSymbol(1)
+        @test y === StaticSymbol(:y)
+        @test z === StaticSymbol(Symbol(1))
         @test @inferred(StaticSymbol(x)) === x
         @test @inferred(StaticSymbol(x, y)) === static(:xy)
+        @test @inferred(StaticSymbol(x, y, z)) === static(:xy1)
     end
 
     @testset "static" begin


### PR DESCRIPTION
Highlight is that `StaticSymbol(static(:x), static(:y))` now results in `static(:xy)` and is type stable.