### PR TITLE
Rework eachop, bug fixes, and test coverage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -299,16 +299,18 @@ eachop(op, args...; iterator) = _eachop(op, args, iterator)
 end
 
 """
-    eachop_tuple(op, args...; iterator::Tuple{Vararg{StaticInt}}) -> Type{Tuple}
+    eachop_tuple(op, arg, args...; iterator::Tuple{Vararg{StaticInt}}) -> Type{Tuple}
 
-Produces a tuple type of `Tuple{op(args..., iterator[1]), op(args..., iterator[2]),...}`.
+Produces a tuple type of `Tuple{op(arg, args..., iterator[1]), op(arg, args..., iterator[2]),...}`.
+Note that if one of the arguments passed to `op` is a `Tuple` type then it should be the first argument
+instead of one of the trailing arguments, ensuring type inference of each element of the tuple.
 """
-eachop_tuple(op, args...; iterator) = _eachop_tuple(op, args, iterator)
-@generated function _eachop_tuple(op, args::A, ::I) where {A,I}
+eachop_tuple(op, arg, args...; iterator) = _eachop_tuple(op, arg, args, iterator)
+@generated function _eachop_tuple(op, arg, args::A, ::I) where {A,I}
     t = Expr(:curly, Tuple)
     narg = length(A.parameters)
     for p in I.parameters
-        call_expr = Expr(:call, :op)
+        call_expr = Expr(:call, :op, :arg)
         if narg > 0
             for i in 1:narg
                 push!(call_expr.args, :(getfield(args, $i)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,7 +229,9 @@ using Test
         @test @inferred(Static.permute(x, y)) === y
         @test @inferred(Static.eachop(getindex;iterator=x)) === x
 
+        get_tuple_add(::Type{T}, ::Type{X}, dim::StaticInt) where {T,X} = Tuple{Static._get_tuple(T, dim),X}
         @test @inferred(Static.eachop_tuple(Static._get_tuple, T; iterator=y)) === Tuple{String,Float64,Int}
+        @test @inferred(Static.eachop_tuple(get_tuple_add, T, String; iterator=y)) === Tuple{Tuple{String,String},Tuple{Float64,String},Tuple{Int,String]ac}}
         @test @inferred(Static.find_first_eq(static(1), y)) === static(3)
         # inferred is Union{Int,Nothing}
         @test Static.find_first_eq(1, map(Int, y)) === 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,7 +231,7 @@ using Test
 
         get_tuple_add(::Type{T}, ::Type{X}, dim::StaticInt) where {T,X} = Tuple{Static._get_tuple(T, dim),X}
         @test @inferred(Static.eachop_tuple(Static._get_tuple, T; iterator=y)) === Tuple{String,Float64,Int}
-        @test @inferred(Static.eachop_tuple(get_tuple_add, T, String; iterator=y)) === Tuple{Tuple{String,String},Tuple{Float64,String},Tuple{Int,String]ac}}
+        @test @inferred(Static.eachop_tuple(get_tuple_add, T, String; iterator=y)) === Tuple{Tuple{String,String},Tuple{Float64,String},Tuple{Int,String}}
         @test @inferred(Static.find_first_eq(static(1), y)) === static(3)
         # inferred is Union{Int,Nothing}
         @test Static.find_first_eq(1, map(Int, y)) === 3


### PR DESCRIPTION
- `eachop` previously accepted one or two repeating arguments to be
passed to `op` for each iteration. Any number of arguments can now be
used. Same for `eachop_tuple`. They each have small doc strings but
probably shouldn't be considered public API.
- `@nif` wasn't imported with `Base.Cartesian` before
- test `permute` and a `StaticSymbol` constructor