### PR TITLE
StaticFloat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.1.2"
+version = "0.2"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.2"
+version = "0.1.3"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://sciml.github.io/Static.jl/dev)
 [![Build Status](https://github.com/SciML/Static.jl/workflows/CI/badge.svg)](https://github.com/SciML/Static.jl/actions)
 [![Coverage](https://codecov.io/gh/SciML/Static.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/Static.jl)
+
+`Static` defines a limited set of statically parameterized types and a common interface that is shared between them. Defining a new static type that conforms with this interface only requires defining the following:
+
+* `Static.static(::T)` - given the non-static type `T` return its static counterpart.
+* `Static.is_static(::Type{S})` - given the static type `S` return `True()`.
+* `Static.known(::Type{S})`- given the static type `S` return the known non-static value.
+
+Fore example, the following would appropriately define the interface for `StaticChar`
+
+```julia
+Static.static(x::Char) = StaticChar(x)
+Static.is_static(::Type{T}) where {T<:StaticChar} = True()
+Static.known(::Type{StaticChar{C}}) where {C} = C::Char
+```

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -15,6 +15,7 @@ end
 
 
 include("static_implementation.jl")
+include("float.jl")
 
 """
     known(::Type{T})
@@ -27,6 +28,7 @@ See also: [`static`](@ref), [`is_static`](@ref)
 @aggressive_constprop known(x) = known(typeof(x))
 known(::Type{T}) where {T} = nothing
 known(::Type{StaticInt{N}}) where {N} = N::Int
+known(::Type{StaticFloat{N}}) where {N} = N::Float
 known(::Type{StaticSymbol{S}}) where {S} = S::Symbol
 known(::Type{Val{V}}) where {V} = V
 known(::Type{True}) = true
@@ -61,6 +63,7 @@ static(:x)
 """
 static(x::X) where {X} = ifelse(is_static(X), identity, _no_static_type)(x)
 @aggressive_constprop static(x::Int) = StaticInt(x)
+@aggressive_constprop static(x::Float) = StaticFloat(x)
 @aggressive_constprop static(x::Bool) = StaticBool(x)
 @aggressive_constprop static(x::Symbol) = StaticSymbol(x)
 @aggressive_constprop static(x::Tuple{Vararg{Any}}) = map(static, x)
@@ -82,6 +85,7 @@ is_static(::Type{T}) where {T<:StaticBool} = True()
 is_static(::Type{T}) where {T<:StaticSymbol} = True()
 is_static(::Type{T}) where {T<:Val} = True()
 is_static(::Type{T}) where {T} = False()
+is_static(::Type{T}) where {T<:StaticFloat} = True()
 _tuple_static(::Type{T}, i) where {T} = is_static(_get_tuple(T, i))
 function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
     if all(eachop(_tuple_static, T; iterator=nstatic(Val(N))))
@@ -90,7 +94,5 @@ function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
         return False()
     end
 end
-
-include("float.jl")
 
 end

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -3,7 +3,7 @@ module Static
 import IfElse: ifelse
 using Base: @propagate_inbounds, Slice
 
-export is_static, known, static, StaticInt, StaticSymbol, True, False, StaticBool
+export is_static, known, static, StaticInt, StaticFloat64, StaticSymbol, True, False, StaticBool
 
 @static if VERSION >= v"1.7.0-DEV.421"
     using Base: @aggressive_constprop

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -3,7 +3,7 @@ module Static
 import IfElse: ifelse
 using Base: @propagate_inbounds, Slice
 
-export static, StaticInt, StaticSymbol, True, False, StaticBool
+export is_static, known, static, StaticInt, StaticSymbol, True, False, StaticBool
 
 @static if VERSION >= v"1.7.0-DEV.421"
     using Base: @aggressive_constprop
@@ -13,6 +13,82 @@ else
     end
 end
 
+
 include("static_implementation.jl")
+
+"""
+    known(::Type{T})
+
+Returns the known value corresponding to a static type `T`. If `T` is not a static type then
+`nothing` is returned.
+
+See also: [`static`](@ref), [`is_static`](@ref)
+"""
+@aggressive_constprop known(x) = known(typeof(x))
+known(::Type{T}) where {T} = nothing
+known(::Type{StaticInt{N}}) where {N} = N::Int
+known(::Type{StaticSymbol{S}}) where {S} = S::Symbol
+known(::Type{Val{V}}) where {V} = V
+known(::Type{True}) = true
+known(::Type{False}) = false
+_get_known(::Type{T}, dim::StaticInt{D}) where {T,D} = known(_get_tuple(T, dim))
+function known(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
+    return eachop(_get_known, T; iterator=nstatic(Val(N)))
+end
+
+
+"""
+    static(x)
+
+Returns a static form of `x`. If `x` is already in a static form then `x` is returned. If
+there is no static alternative for `x` then an error is thrown.
+
+See also: [`is_static`](@ref), [`known`](@ref)
+
+```julia
+julia> using ArrayInterface: static
+
+julia> static(1)
+static(1)
+
+julia> static(true)
+ArrayInterface.True()
+
+julia> static(:x)
+static(:x)
+
+```
+"""
+static(x::X) where {X} = ifelse(is_static(X), identity, _no_static_type)(x)
+@aggressive_constprop static(x::Int) = StaticInt(x)
+@aggressive_constprop static(x::Bool) = StaticBool(x)
+@aggressive_constprop static(x::Symbol) = StaticSymbol(x)
+@aggressive_constprop static(x::Tuple{Vararg{Any}}) = map(static, x)
+@generated static(::Val{V}) where {V} = static(V)
+function _no_static_type(@nospecialize(x))
+    error("There is no static alternative for type $(typeof(x)).")
+end
+
+"""
+    is_static(::Type{T}) -> StaticBool
+
+Returns `True` if `T` is a static type.
+
+See also: [`static`](@ref), [`known`](@ref)
+"""
+@aggressive_constprop is_static(x) = is_static(typeof(x))
+is_static(::Type{T}) where {T<:StaticInt} = True()
+is_static(::Type{T}) where {T<:StaticBool} = True()
+is_static(::Type{T}) where {T<:StaticSymbol} = True()
+is_static(::Type{T}) where {T<:Val} = True()
+is_static(::Type{T}) where {T} = False()
+_tuple_static(::Type{T}, i) where {T} = is_static(_get_tuple(T, i))
+function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
+    if all(eachop(_tuple_static, T; iterator=nstatic(Val(N))))
+        return True()
+    else
+        return False()
+    end
+end
 
 end

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -29,7 +29,7 @@ known
 @aggressive_constprop known(x) = known(typeof(x))
 known(::Type{T}) where {T} = nothing
 known(::Type{StaticInt{N}}) where {N} = N::Int
-known(::Type{StaticFloat{N}}) where {N} = N::Float
+known(::Type{StaticFloat{N}}) where {N} = N::Float64
 known(::Type{StaticSymbol{S}}) where {S} = S::Symbol
 known(::Type{Val{V}}) where {V} = V
 known(::Type{True}) = true
@@ -65,7 +65,7 @@ static(:x)
 static
 @aggressive_constprop static(x::X) where {X} = ifelse(is_static(X), identity, _no_static_type)(x)
 @aggressive_constprop static(x::Int) = StaticInt(x)
-@aggressive_constprop static(x::Float) = StaticFloat(x)
+@aggressive_constprop static(x::Float64) = StaticFloat(x)
 @aggressive_constprop static(x::Bool) = StaticBool(x)
 @aggressive_constprop static(x::Symbol) = StaticSymbol(x)
 @aggressive_constprop static(x::Tuple{Vararg{Any}}) = map(static, x)

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -91,4 +91,6 @@ function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
     end
 end
 
+include("float.jl")
+
 end

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -29,7 +29,7 @@ known
 @aggressive_constprop known(x) = known(typeof(x))
 known(::Type{T}) where {T} = nothing
 known(::Type{StaticInt{N}}) where {N} = N::Int
-known(::Type{StaticFloat{N}}) where {N} = N::Float64
+known(::Type{StaticFloat64{N}}) where {N} = N::Float64
 known(::Type{StaticSymbol{S}}) where {S} = S::Symbol
 known(::Type{Val{V}}) where {V} = V
 known(::Type{True}) = true
@@ -65,7 +65,7 @@ static(:x)
 static
 @aggressive_constprop static(x::X) where {X} = ifelse(is_static(X), identity, _no_static_type)(x)
 @aggressive_constprop static(x::Int) = StaticInt(x)
-@aggressive_constprop static(x::Float64) = StaticFloat(x)
+@aggressive_constprop static(x::Float64) = StaticFloat64(x)
 @aggressive_constprop static(x::Bool) = StaticBool(x)
 @aggressive_constprop static(x::Symbol) = StaticSymbol(x)
 @aggressive_constprop static(x::Tuple{Vararg{Any}}) = map(static, x)
@@ -88,7 +88,7 @@ is_static(::Type{T}) where {T<:StaticBool} = True()
 is_static(::Type{T}) where {T<:StaticSymbol} = True()
 is_static(::Type{T}) where {T<:Val} = True()
 is_static(::Type{T}) where {T} = False()
-is_static(::Type{T}) where {T<:StaticFloat} = True()
+is_static(::Type{T}) where {T<:StaticFloat64} = True()
 @aggressive_constprop _tuple_static(::Type{T}, i) where {T} = is_static(_get_tuple(T, i))
 function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
     if all(eachop(_tuple_static, T; iterator=nstatic(Val(N))))

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -25,6 +25,7 @@ Returns the known value corresponding to a static type `T`. If `T` is not a stat
 
 See also: [`static`](@ref), [`is_static`](@ref)
 """
+known
 @aggressive_constprop known(x) = known(typeof(x))
 known(::Type{T}) where {T} = nothing
 known(::Type{StaticInt{N}}) where {N} = N::Int
@@ -61,7 +62,8 @@ static(:x)
 
 ```
 """
-static(x::X) where {X} = ifelse(is_static(X), identity, _no_static_type)(x)
+static
+@aggressive_constprop static(x::X) where {X} = ifelse(is_static(X), identity, _no_static_type)(x)
 @aggressive_constprop static(x::Int) = StaticInt(x)
 @aggressive_constprop static(x::Float) = StaticFloat(x)
 @aggressive_constprop static(x::Bool) = StaticBool(x)
@@ -79,6 +81,7 @@ Returns `True` if `T` is a static type.
 
 See also: [`static`](@ref), [`known`](@ref)
 """
+is_static
 @aggressive_constprop is_static(x) = is_static(typeof(x))
 is_static(::Type{T}) where {T<:StaticInt} = True()
 is_static(::Type{T}) where {T<:StaticBool} = True()
@@ -86,7 +89,7 @@ is_static(::Type{T}) where {T<:StaticSymbol} = True()
 is_static(::Type{T}) where {T<:Val} = True()
 is_static(::Type{T}) where {T} = False()
 is_static(::Type{T}) where {T<:StaticFloat} = True()
-_tuple_static(::Type{T}, i) where {T} = is_static(_get_tuple(T, i))
+@aggressive_constprop _tuple_static(::Type{T}, i) where {T} = is_static(_get_tuple(T, i))
 function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
     if all(eachop(_tuple_static, T; iterator=nstatic(Val(N))))
         return True()

--- a/src/float.jl
+++ b/src/float.jl
@@ -26,6 +26,10 @@ Base.show(io::IO, ::StaticFloat{N}) where {N} = print(io, "static($N)")
 Base.convert(::Type{T}, ::StaticFloat{N}) where {N,T<:AbstractFloat} = T(N)
 Base.promote_rule(::Type{StaticFloat{N}}, ::Type{T}) where {N,T} = promote_type(T, Float64)
 
+@static if VERSION == v"1.2"
+    Base.promote_rule(::Type{StaticFloat{N}}, ::Type{Any}) where {N} = Any
+end
+
 Base.eltype(::Type{T}) where {T<:StaticFloat} = Float64
 Base.iszero(::FloatZero) = true
 Base.iszero(::StaticFloat) = false

--- a/src/float.jl
+++ b/src/float.jl
@@ -1,6 +1,12 @@
 
 const Float = Int === Int64 ? Float64 : Float32
 
+"""
+    StaticFloat{N}
+
+A statically sized `$Float`.
+Use `StaticInt(N)` instead of `Val(N)` when you want it to behave like a number.
+"""
 struct StaticFloat{N} <: AbstractFloat
     StaticFloat{N}() where {N} = new{N::Float}()
     StaticFloat(x::Float) = new{x}()

--- a/src/float.jl
+++ b/src/float.jl
@@ -3,19 +3,20 @@ const Float = Int === Int64 ? Float64 : Float32
 
 struct StaticFloat{N} <: AbstractFloat
     StaticFloat{N}() where {N} = new{N::Float}()
-    StaticFloat(x::Float) = new{N}()
+    StaticFloat(x::Float) = new{x}()
+    StaticFloat(x::Int) = new{Base.sitofp(Float, x)::Float}()
 end
+
+(::Type{T})(x::Integer) where {T<:StaticFloat} = StaticFloat(x)
+(::Type{T})(x::AbstractFloat) where {T<:StaticFloat} = StaticFloat(x)
+@generated function Base.float(::StaticInt{N}) where {N}
+    Expr(:call, Expr(:curly, :StaticFloat, float(N)))
+end
+StaticFloat(x::StaticInt{N}) where {N} = float(x)
 
 const FloatOne = StaticFloat{one(Float)}
 const FloatZero = StaticFloat{zero(Float)}
 
-Base.@pure StaticFloat(x::Float) = StaticFloat{x}()
-Base.@pure StaticFloat(x::Int) = StaticFloat{Base.sitofp(Float, x)}()
-@generated StatiFloat(::StaticInt{N}) where {N} = Expr(:call, Expr(:curly, :StaticFloat, Float(N)))
-
-@aggressive_constprop static(x::Float) = StaticFloat(x)
-is_static(::Type{T}) where {T<:StaticFloat} = True()
-known(::Type{StaticFloat{N}}) where {N} = N::Float
 Base.show(io::IO, ::StaticFloat{N}) where {N} = print(io, "static($N)")
 
 Base.convert(::Type{T}, ::StaticFloat{N}) where {N,T<:AbstractFloat} = T(N)
@@ -46,34 +47,47 @@ Base.@pure function fmul(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
 end
 
 Base.:+(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fadd(x, y)
-Base.:+(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fadd(x, StaticFloat(y))
-Base.:+(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fadd(StaticFloat(x), y)
+Base.:+(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = +(x, float(y))
+Base.:+(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = +(float(x), y)
+Base.:+(x::FloatZero, ::FloatZero) = x
+Base.:+(x::StaticFloat{X}, ::FloatZero) where {X} = x
+Base.:+(::FloatZero, y::StaticFloat{Y}) where {Y} = y
+Base.:+(x::StaticFloat{X}, ::Zero) where {X} = x
+Base.:+(::Zero, y::StaticFloat{Y}) where {Y} = y
 
+Base.:-(::StaticFloat{X}) where {X} = StaticFloat{-X}()
 Base.:-(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fsub(x, y)
-Base.:-(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fsub(x, StaticFloat(y))
-Base.:-(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fsub(StaticFloat(x), y)
+Base.:-(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = -(x, float(y))
+Base.:-(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = -(float(x), y)
+Base.:-(x::FloatZero, ::FloatZero) = x
+Base.:-(x::StaticFloat{X}, ::FloatZero) where {X} = x
+Base.:-(x::StaticFloat{X}, ::Zero) where {X} = x
+Base.:-(::FloatZero, y::StaticFloat{Y}) where {Y} = -y
+Base.:-(::Zero, y::StaticFloat{Y}) where {Y} = -y
 
 Base.:*(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fmul(x, y)
-Base.:*(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fmul(x, StaticFloat(y))
-Base.:*(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fmul(StaticFloat(x), y)
+Base.:*(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = *(x, float(y))
+Base.:*(::StaticFloat{X}, ::Zero) where {X} = FloatZero()
+Base.:*(::Zero, ::StaticFloat{Y}, ) where {Y} = FloatZero()
+Base.:*(x::StaticFloat{X}, ::One) where {X} = x
+Base.:*(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = *(float(x), y)
+Base.:*(::One, y::StaticFloat{Y}) where {Y} = y
+Base.:*(x::FloatZero, ::FloatZero) = x
+Base.:*(::StaticFloat{X}, y::FloatZero) where {X} = y
+Base.:*(x::FloatZero, ::StaticFloat{Y}) where {Y} = x
+Base.:*(x::FloatZero, ::FloatOne) = x
+Base.:*(x::FloatOne, ::FloatOne) = x
+Base.:*(x::StaticFloat{X}, ::FloatOne) where {X} = x
+Base.:*(::FloatOne, y::StaticFloat{Y}) where {Y} = y
+Base.:*(::FloatOne, y::FloatZero) = y
+
 
 Base.:/(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fdiv(x, y)
-Base.:/(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fdiv(x, StaticFloat(y))
-Base.:/(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fdiv(StaticFloat(x), y)
+Base.:/(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = /(x, float(y))
+Base.:/(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = /(float(x), y)
 
 @generated Base.sqrt(::StaticInt{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, sqrt(M)))
 @generated Base.sqrt(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, sqrt(M)))
-
-Base.:+(x::StaticFloat{N}, y::StaticInt{0}) where {N} = x
-Base.:+(x::StaticInt{0}, y::StaticFloat{N}) where {N} = y
-
-Base.:-(x::StaticFloat{N}, y::StaticInt{0}) where {N} = x
-Base.:-(x::StaticInt{0}, y::StaticFloat{N}) where {N} = -x
-
-Base.:*(x::StaticFloat{N}, y::StaticInt{0}) where {N} = zero(x)
-Base.:*(x::StaticInt{0}, y::StaticFloat{N}) where {N} = zero(y)
-Base.:*(x::StaticFloat{N}, y::StaticInt{1}) where {N} = x
-Base.:*(x::StaticInt{1}, y::StaticFloat{N}) where {N} = y
 
 @generated Base.round(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, round(M)))
 @generated roundtostaticint(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticInt, round(Int, M)))
@@ -82,3 +96,4 @@ roundtostaticint(x::AbstractFloat) = round(Int, x)
 floortostaticint(x::AbstractFloat) = Base.fptosi(Int, x)
 
 Base.inv(x::StaticFloat{N}) where {N} = fdiv(one(x), x)
+

--- a/src/float.jl
+++ b/src/float.jl
@@ -1,0 +1,84 @@
+
+const Float = Int === Int64 ? Float64 : Float32
+
+struct StaticFloat{N} <: AbstractFloat
+    StaticFloat{N}() where {N} = new{N::Float}()
+    StaticFloat(x::Float) = new{N}()
+end
+
+const FloatOne = StaticFloat{one(Float)}
+const FloatZero = StaticFloat{zero(Float)}
+
+Base.@pure StaticFloat(x::Float) = StaticFloat{x}()
+Base.@pure StaticFloat(x::Int) = StaticFloat{Base.sitofp(Float, x)}()
+@generated StatiFloat(::StaticInt{N}) where {N} = Expr(:call, Expr(:curly, :StaticFloat, Float(N)))
+
+@aggressive_constprop static(x::Float) = StaticFloat(x)
+is_static(::Type{T}) where {T<:StaticFloat} = True()
+known(::Type{StaticFloat{N}}) where {N} = N::Float
+Base.show(io::IO, ::StaticFloat{N}) where {N} = print(io, "static($N)")
+
+Base.convert(::Type{T}, ::StaticFloat{N}) where {N,T<:AbstractFloat} = T(N)
+Base.promote_rule(::Type{StaticFloat{N}}, ::Type{T}) where {N,T} = promote_type(T, Float)
+
+Base.eltype(::Type{T}) where {T<:StaticFloat} = Float
+Base.iszero(::FloatZero) = true
+Base.iszero(::StaticFloat) = false
+Base.isone(::FloatOne) = true
+Base.isone(::StaticFloat) = false
+Base.zero(::Type{T}) where {T<:StaticFloat} = FloatZero()
+Base.one(::Type{T}) where {T<:StaticFloat} = FloatOne()
+
+Base.@pure function fsub(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
+    return StaticFloat{Base.sub_float(X, Y)::Float}()
+end
+
+Base.@pure function fadd(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
+    return StaticFloat{Base.add_float(X, Y)::Float}()
+end
+
+Base.@pure function fdiv(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
+    return StaticFloat{Base.div_float(X, Y)::Float}()
+end
+
+Base.@pure function fmul(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
+    return StaticFloat{Base.mul_float(X, Y)::Float}()
+end
+
+Base.:+(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fadd(x, y)
+Base.:+(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fadd(x, StaticFloat(y))
+Base.:+(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fadd(StaticFloat(x), y)
+
+Base.:-(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fsub(x, y)
+Base.:-(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fsub(x, StaticFloat(y))
+Base.:-(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fsub(StaticFloat(x), y)
+
+Base.:*(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fmul(x, y)
+Base.:*(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fmul(x, StaticFloat(y))
+Base.:*(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fmul(StaticFloat(x), y)
+
+Base.:/(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fdiv(x, y)
+Base.:/(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = fdiv(x, StaticFloat(y))
+Base.:/(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = fdiv(StaticFloat(x), y)
+
+@generated Base.sqrt(::StaticInt{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, sqrt(M)))
+@generated Base.sqrt(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, sqrt(M)))
+
+Base.:+(x::StaticFloat{N}, y::StaticInt{0}) where {N} = x
+Base.:+(x::StaticInt{0}, y::StaticFloat{N}) where {N} = y
+
+Base.:-(x::StaticFloat{N}, y::StaticInt{0}) where {N} = x
+Base.:-(x::StaticInt{0}, y::StaticFloat{N}) where {N} = -x
+
+Base.:*(x::StaticFloat{N}, y::StaticInt{0}) where {N} = zero(x)
+Base.:*(x::StaticInt{0}, y::StaticFloat{N}) where {N} = zero(y)
+Base.:*(x::StaticFloat{N}, y::StaticInt{1}) where {N} = x
+Base.:*(x::StaticInt{1}, y::StaticFloat{N}) where {N} = y
+
+@generated Base.round(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, round(M)))
+@generated roundtostaticint(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticInt, round(Int, M)))
+roundtostaticint(x::AbstractFloat) = round(Int, x)
+@generated floortostaticint(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticInt, floor(Int, M)))
+floortostaticint(x::AbstractFloat) = Base.fptosi(Int, x)
+
+Base.inv(x::StaticFloat{N}) where {N} = fdiv(one(x), x)

--- a/src/float.jl
+++ b/src/float.jl
@@ -1,111 +1,112 @@
 
-const Float = Int === Int64 ? Float64 : Float32
-
 """
-    StaticFloat{N}
+    StaticFloat64{N}
 
-A statically sized `Float`.
+A statically sized `Float64`.
 Use `StaticInt(N)` instead of `Val(N)` when you want it to behave like a number.
 """
-struct StaticFloat{N} <: AbstractFloat
-    StaticFloat{N}() where {N} = new{N::Float}()
-    StaticFloat(x::Float) = new{x}()
-    StaticFloat(x::Int) = new{Base.sitofp(Float, x)::Float}()
+struct StaticFloat64{N} <: AbstractFloat
+    StaticFloat64{N}() where {N} = new{N::Float64}()
+    StaticFloat64(x::Float64) = new{x}()
+    StaticFloat64(x::Int) = new{Base.sitofp(Float64, x)::Float64}()
 end
 
-(::Type{T})(x::Integer) where {T<:StaticFloat} = StaticFloat(x)
-(::Type{T})(x::AbstractFloat) where {T<:StaticFloat} = StaticFloat(x)
+(::Type{T})(x::Integer) where {T<:StaticFloat64} = StaticFloat64(x)
+(::Type{T})(x::AbstractFloat) where {T<:StaticFloat64} = StaticFloat64(x)
 @generated function Base.AbstractFloat(::StaticInt{N}) where {N}
-    Expr(:call, Expr(:curly, :StaticFloat, Float(N)))
+    Expr(:call, Expr(:curly, :StaticFloat64, Float64(N)))
 end
-StaticFloat(x::StaticInt{N}) where {N} = float(x)
+StaticFloat64(x::StaticInt{N}) where {N} = float(x)
 
-const FloatOne = StaticFloat{one(Float)}
-const FloatZero = StaticFloat{zero(Float)}
+const FloatOne = StaticFloat64{one(Float64)}
+const FloatZero = StaticFloat64{zero(Float64)}
 
-Base.show(io::IO, ::StaticFloat{N}) where {N} = print(io, "static($N)")
+Base.show(io::IO, ::StaticFloat64{N}) where {N} = print(io, "static($N)")
 
-Base.convert(::Type{T}, ::StaticFloat{N}) where {N,T<:AbstractFloat} = T(N)
-Base.promote_rule(::Type{StaticFloat{N}}, ::Type{T}) where {N,T} = promote_type(T, Float)
+Base.convert(::Type{T}, ::StaticFloat64{N}) where {N,T<:AbstractFloat} = T(N)
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{T}) where {N,T} = promote_type(T, Float64)
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float64}) where {N} = Float64
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float32}) where {N} = Float32
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float16}) where {N} = Float16
 
 @static if VERSION == v"1.2"
-    Base.promote_rule(::Type{StaticFloat{N}}, ::Type{Any}) where {N} = Any
+    Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Any}) where {N} = Any
 end
 
-Base.eltype(::Type{T}) where {T<:StaticFloat} = Float
+Base.eltype(::Type{T}) where {T<:StaticFloat64} = Float64
 Base.iszero(::FloatZero) = true
-Base.iszero(::StaticFloat) = false
+Base.iszero(::StaticFloat64) = false
 Base.isone(::FloatOne) = true
-Base.isone(::StaticFloat) = false
-Base.zero(::Type{T}) where {T<:StaticFloat} = FloatZero()
-Base.one(::Type{T}) where {T<:StaticFloat} = FloatOne()
+Base.isone(::StaticFloat64) = false
+Base.zero(::Type{T}) where {T<:StaticFloat64} = FloatZero()
+Base.one(::Type{T}) where {T<:StaticFloat64} = FloatOne()
 
-Base.@pure function fsub(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.sub_float(X, Y)::Float}()
+Base.@pure function fsub(::StaticFloat64{X}, ::StaticFloat64{Y}) where {X,Y}
+    return StaticFloat64{Base.sub_float(X, Y)::Float64}()
 end
 
-Base.@pure function fadd(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.add_float(X, Y)::Float}()
+Base.@pure function fadd(::StaticFloat64{X}, ::StaticFloat64{Y}) where {X,Y}
+    return StaticFloat64{Base.add_float(X, Y)::Float64}()
 end
 
-Base.@pure function fdiv(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.div_float(X, Y)::Float}()
+Base.@pure function fdiv(::StaticFloat64{X}, ::StaticFloat64{Y}) where {X,Y}
+    return StaticFloat64{Base.div_float(X, Y)::Float64}()
 end
 
-Base.@pure function fmul(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.mul_float(X, Y)::Float}()
+Base.@pure function fmul(::StaticFloat64{X}, ::StaticFloat64{Y}) where {X,Y}
+    return StaticFloat64{Base.mul_float(X, Y)::Float64}()
 end
 
-Base.:+(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fadd(x, y)
-Base.:+(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = +(x, float(y))
-Base.:+(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = +(float(x), y)
+Base.:+(x::StaticFloat64{X}, y::StaticFloat64{Y}) where {X,Y} = fadd(x, y)
+Base.:+(x::StaticFloat64{X}, y::StaticInt{Y}) where {X,Y} = +(x, float(y))
+Base.:+(x::StaticInt{X}, y::StaticFloat64{Y}) where {X,Y} = +(float(x), y)
 Base.:+(x::FloatZero, ::FloatZero) = x
-Base.:+(x::StaticFloat{X}, ::FloatZero) where {X} = x
-Base.:+(::FloatZero, y::StaticFloat{Y}) where {Y} = y
-Base.:+(x::StaticFloat{X}, ::Zero) where {X} = x
-Base.:+(::Zero, y::StaticFloat{Y}) where {Y} = y
+Base.:+(x::StaticFloat64{X}, ::FloatZero) where {X} = x
+Base.:+(::FloatZero, y::StaticFloat64{Y}) where {Y} = y
+Base.:+(x::StaticFloat64{X}, ::Zero) where {X} = x
+Base.:+(::Zero, y::StaticFloat64{Y}) where {Y} = y
 
-Base.:-(::StaticFloat{X}) where {X} = StaticFloat{-X}()
-Base.:-(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fsub(x, y)
-Base.:-(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = -(x, float(y))
-Base.:-(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = -(float(x), y)
+Base.:-(::StaticFloat64{X}) where {X} = StaticFloat64{-X}()
+Base.:-(x::StaticFloat64{X}, y::StaticFloat64{Y}) where {X,Y} = fsub(x, y)
+Base.:-(x::StaticFloat64{X}, y::StaticInt{Y}) where {X,Y} = -(x, float(y))
+Base.:-(x::StaticInt{X}, y::StaticFloat64{Y}) where {X,Y} = -(float(x), y)
 Base.:-(x::FloatZero, ::FloatZero) = x
-Base.:-(x::StaticFloat{X}, ::FloatZero) where {X} = x
-Base.:-(x::StaticFloat{X}, ::Zero) where {X} = x
-Base.:-(::FloatZero, y::StaticFloat{Y}) where {Y} = -y
-Base.:-(::Zero, y::StaticFloat{Y}) where {Y} = -y
+Base.:-(x::StaticFloat64{X}, ::FloatZero) where {X} = x
+Base.:-(x::StaticFloat64{X}, ::Zero) where {X} = x
+Base.:-(::FloatZero, y::StaticFloat64{Y}) where {Y} = -y
+Base.:-(::Zero, y::StaticFloat64{Y}) where {Y} = -y
 
-Base.:*(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fmul(x, y)
-Base.:*(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = *(x, float(y))
-Base.:*(::StaticFloat{X}, ::Zero) where {X} = FloatZero()
-Base.:*(::Zero, ::StaticFloat{Y}, ) where {Y} = FloatZero()
-Base.:*(x::StaticFloat{X}, ::One) where {X} = x
-Base.:*(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = *(float(x), y)
-Base.:*(::One, y::StaticFloat{Y}) where {Y} = y
+Base.:*(x::StaticFloat64{X}, y::StaticFloat64{Y}) where {X,Y} = fmul(x, y)
+Base.:*(x::StaticFloat64{X}, y::StaticInt{Y}) where {X,Y} = *(x, float(y))
+Base.:*(::StaticFloat64{X}, ::Zero) where {X} = FloatZero()
+Base.:*(::Zero, ::StaticFloat64{Y}, ) where {Y} = FloatZero()
+Base.:*(x::StaticFloat64{X}, ::One) where {X} = x
+Base.:*(x::StaticInt{X}, y::StaticFloat64{Y}) where {X,Y} = *(float(x), y)
+Base.:*(::One, y::StaticFloat64{Y}) where {Y} = y
 Base.:*(x::FloatZero, ::FloatZero) = x
-Base.:*(::StaticFloat{X}, y::FloatZero) where {X} = y
-Base.:*(x::FloatZero, ::StaticFloat{Y}) where {Y} = x
+Base.:*(::StaticFloat64{X}, y::FloatZero) where {X} = y
+Base.:*(x::FloatZero, ::StaticFloat64{Y}) where {Y} = x
 Base.:*(x::FloatZero, ::FloatOne) = x
 Base.:*(x::FloatOne, ::FloatOne) = x
-Base.:*(x::StaticFloat{X}, ::FloatOne) where {X} = x
-Base.:*(::FloatOne, y::StaticFloat{Y}) where {Y} = y
+Base.:*(x::StaticFloat64{X}, ::FloatOne) where {X} = x
+Base.:*(::FloatOne, y::StaticFloat64{Y}) where {Y} = y
 Base.:*(::FloatOne, y::FloatZero) = y
 
 
-Base.:/(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fdiv(x, y)
-Base.:/(x::StaticFloat{X}, y::StaticInt{Y}) where {X,Y} = /(x, float(y))
-Base.:/(x::StaticInt{X}, y::StaticFloat{Y}) where {X,Y} = /(float(x), y)
+Base.:/(x::StaticFloat64{X}, y::StaticFloat64{Y}) where {X,Y} = fdiv(x, y)
+Base.:/(x::StaticFloat64{X}, y::StaticInt{Y}) where {X,Y} = /(x, float(y))
+Base.:/(x::StaticInt{X}, y::StaticFloat64{Y}) where {X,Y} = /(float(x), y)
 
-@generated Base.sqrt(::StaticInt{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, sqrt(M)))
-@generated Base.sqrt(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, sqrt(M)))
+@generated Base.sqrt(::StaticInt{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat64, sqrt(M)))
+@generated Base.sqrt(::StaticFloat64{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat64, sqrt(M)))
 
-@generated Base.round(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat, round(M)))
-@generated roundtostaticint(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticInt, round(Int, M)))
+@generated Base.round(::StaticFloat64{M}) where {M} = Expr(:call, Expr(:curly, :StaticFloat64, round(M)))
+@generated roundtostaticint(::StaticFloat64{M}) where {M} = Expr(:call, Expr(:curly, :StaticInt, round(Int, M)))
 roundtostaticint(x::AbstractFloat) = round(Int, x)
-@generated floortostaticint(::StaticFloat{M}) where {M} = Expr(:call, Expr(:curly, :StaticInt, floor(Int, M)))
+@generated floortostaticint(::StaticFloat64{M}) where {M} = Expr(:call, Expr(:curly, :StaticInt, floor(Int, M)))
 floortostaticint(x::AbstractFloat) = Base.fptosi(Int, x)
 
-Base.:(^)(::StaticFloat{x}, y::Float) where {x} = exp2(log2(x) * y)
+Base.:(^)(::StaticFloat64{x}, y::Float64) where {x} = exp2(log2(x) * y)
 
-Base.inv(x::StaticFloat{N}) where {N} = fdiv(one(x), x)
+Base.inv(x::StaticFloat64{N}) where {N} = fdiv(one(x), x)
 

--- a/src/float.jl
+++ b/src/float.jl
@@ -1,34 +1,32 @@
 
-const Float = Int === Int64 ? Float64 : Float32
-
 """
     StaticFloat{N}
 
-A statically sized `$Float`.
+A statically sized `Float64`.
 Use `StaticInt(N)` instead of `Val(N)` when you want it to behave like a number.
 """
 struct StaticFloat{N} <: AbstractFloat
-    StaticFloat{N}() where {N} = new{N::Float}()
-    StaticFloat(x::Float) = new{x}()
-    StaticFloat(x::Int) = new{Base.sitofp(Float, x)::Float}()
+    StaticFloat{N}() where {N} = new{N::Float64}()
+    StaticFloat(x::Float64) = new{x}()
+    StaticFloat(x::Int) = new{Base.sitofp(Float64, x)::Float64}()
 end
 
 (::Type{T})(x::Integer) where {T<:StaticFloat} = StaticFloat(x)
 (::Type{T})(x::AbstractFloat) where {T<:StaticFloat} = StaticFloat(x)
-@generated function Base.float(::StaticInt{N}) where {N}
-    Expr(:call, Expr(:curly, :StaticFloat, float(N)))
+@generated function Base.AbstractFloat(::StaticInt{N}) where {N}
+    Expr(:call, Expr(:curly, :StaticFloat, AbstractFloat(N)))
 end
 StaticFloat(x::StaticInt{N}) where {N} = float(x)
 
-const FloatOne = StaticFloat{one(Float)}
-const FloatZero = StaticFloat{zero(Float)}
+const FloatOne = StaticFloat{one(Float64)}
+const FloatZero = StaticFloat{zero(Float64)}
 
 Base.show(io::IO, ::StaticFloat{N}) where {N} = print(io, "static($N)")
 
 Base.convert(::Type{T}, ::StaticFloat{N}) where {N,T<:AbstractFloat} = T(N)
-Base.promote_rule(::Type{StaticFloat{N}}, ::Type{T}) where {N,T} = promote_type(T, Float)
+Base.promote_rule(::Type{StaticFloat{N}}, ::Type{T}) where {N,T} = promote_type(T, Float64)
 
-Base.eltype(::Type{T}) where {T<:StaticFloat} = Float
+Base.eltype(::Type{T}) where {T<:StaticFloat} = Float64
 Base.iszero(::FloatZero) = true
 Base.iszero(::StaticFloat) = false
 Base.isone(::FloatOne) = true
@@ -37,19 +35,19 @@ Base.zero(::Type{T}) where {T<:StaticFloat} = FloatZero()
 Base.one(::Type{T}) where {T<:StaticFloat} = FloatOne()
 
 Base.@pure function fsub(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.sub_float(X, Y)::Float}()
+    return StaticFloat{Base.sub_float(X, Y)::Float64}()
 end
 
 Base.@pure function fadd(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.add_float(X, Y)::Float}()
+    return StaticFloat{Base.add_float(X, Y)::Float64}()
 end
 
 Base.@pure function fdiv(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.div_float(X, Y)::Float}()
+    return StaticFloat{Base.div_float(X, Y)::Float64}()
 end
 
 Base.@pure function fmul(::StaticFloat{X}, ::StaticFloat{Y}) where {X,Y}
-    return StaticFloat{Base.mul_float(X, Y)::Float}()
+    return StaticFloat{Base.mul_float(X, Y)::Float64}()
 end
 
 Base.:+(x::StaticFloat{X}, y::StaticFloat{Y}) where {X,Y} = fadd(x, y)

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -26,7 +26,6 @@ Base.Integer(x::StaticInt{N}) where {N} = x
 (::Type{T})(x::StaticInt{N}) where {T<:Integer,N} = T(N)
 (::Type{T})(x::Int) where {T<:StaticInt} = StaticInt(x)
 Base.convert(::Type{StaticInt{N}}, ::StaticInt{N}) where {N} = StaticInt{N}()
-Base.float(::StaticInt{N}) where {N} = Float64(N)
 
 Base.promote_rule(::Type{<:StaticInt}, ::Type{T}) where {T<:Number} = promote_type(Int, T)
 function Base.promote_rule(::Type{<:StaticInt}, ::Type{T}) where {T<:AbstractIrrational}

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -416,58 +416,6 @@ Base.Symbol(::StaticSymbol{s}) where {s} = s::Symbol
 
 Base.show(io::IO, ::StaticSymbol{s}) where {s} = print(io, "static(:$s)")
 
-is_static(x) = is_static(typeof(x))
-is_static(::Type{T}) where {T<:StaticInt} = True()
-is_static(::Type{T}) where {T<:StaticBool} = True()
-is_static(::Type{T}) where {T<:StaticSymbol} = True()
-is_static(::Type{T}) where {T} = False()
-
-_tuple_static(::Type{T}, i) where {T} = is_static(_get_tuple(T, i))
-function is_static(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}}
-    if all(eachop(_tuple_static, T; iterator=nstatic(Val(N))))
-        return True()
-    else
-        return False()
-    end
-end
-
-"""
-    static(x)
-
-Returns a static form of `x`. If `x` is already in a static form then `x` is returned. If
-there is no static alternative for `x` then an error is thrown.
-
-```julia
-julia> using ArrayInterface: static
-
-julia> static(1)
-static(1)
-
-julia> static(true)
-ArrayInterface.True()
-
-julia> static(:x)
-static(:x)
-
-```
-"""
-function static end
-@aggressive_constprop static(x::Int) = StaticInt(x)
-@aggressive_constprop static(x::Bool) = StaticBool(x)
-@aggressive_constprop static(x::Symbol) = StaticSymbol(x)
-@aggressive_constprop static(x::Tuple{Vararg{Any}}) = map(static, x)
-function static(x)
-    if is_static(x) === True()
-        return x
-    else
-        _no_static_type(x)
-    end
-end
-@generated static(::Val{V}) where {V} = static(V)
-function _no_static_type(@nospecialize(x))
-    error("There is no static alternative for type $(typeof(x)).")
-end
-
 #=
     find_first_eq(x, collection::Tuple)
 

--- a/test/float.jl
+++ b/test/float.jl
@@ -1,5 +1,4 @@
-
-@testset "Static Numbers" begin
+@testset "StaticFloat" begin
     for i ∈ -10:10
         for j ∈ -10:10
             @test i+j == @inferred(Static.StaticInt(i) + Static.StaticFloat(j)) == @inferred(i + Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) + j) == @inferred(Static.StaticFloat(i) + Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) + Static.StaticFloat(j))
@@ -23,4 +22,21 @@
     @test @inferred(Static.roundtostaticint(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticInt(2)
     @test @inferred(round(Static.StaticFloat(1.0))) === Static.StaticFloat(1)
     @test @inferred(round(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticFloat(2)
+
+    fone = static(1.0)
+    fzero = static(0.0)
+    @test @inferred(isone(fone))
+    @test @inferred(isone(one(fzero)))
+    @test @inferred(isone(fzero)) === false
+
+    @test @inferred(iszero(fone)) === false
+    @test @inferred(iszero(fzero))
+    @test @inferred(iszero(zero(typeof(fzero))))
+
+    @test typeof(fone)(1) isa Static.StaticFloat
+    @test typeof(fone)(1.0) isa Static.StaticFloat
+
+    @test @inferred(eltype(Static.StaticFloat(static(1)))) <: Static.Float
+    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Static.Float, Int)
 end
+

--- a/test/float.jl
+++ b/test/float.jl
@@ -1,3 +1,4 @@
+
 @testset "StaticFloat" begin
     for i ∈ -10:10
         for j ∈ -10:10
@@ -36,7 +37,10 @@
     @test typeof(fone)(1) isa Static.StaticFloat
     @test typeof(fone)(1.0) isa Static.StaticFloat
 
-    @test @inferred(eltype(Static.StaticFloat(static(1)))) <: Static.Float
-    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Static.Float, Int)
+    @test @inferred(eltype(Static.StaticFloat(static(1)))) <: Float64
+    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Float64, Int)
+
+    @test @inferred(inv(static(2.0))) === static(inv(2.0))
+
 end
 

--- a/test/float.jl
+++ b/test/float.jl
@@ -1,0 +1,26 @@
+
+@testset "Static Numbers" begin
+    for i ∈ -10:10
+        for j ∈ -10:10
+            @test i+j == @inferred(Static.StaticInt(i) + Static.StaticFloat(j)) == @inferred(i + Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) + j) == @inferred(Static.StaticFloat(i) + Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) + Static.StaticFloat(j))
+            @test i-j == @inferred(Static.StaticInt(i) - Static.StaticFloat(j)) == @inferred(i - Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) - Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) - j) == @inferred(Static.StaticFloat(i) - Static.StaticFloat(j))
+            @test i*j == @inferred(Static.StaticInt(i) * Static.StaticFloat(j)) == @inferred(i * Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) * Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) * j) == @inferred(Static.StaticFloat(i) * Static.StaticFloat(j))
+            i == j == 0 && continue
+            @test i/j == @inferred(Static.StaticInt(i) / Static.StaticFloat(j)) == @inferred(i / Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) / Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) / j) == @inferred(Static.StaticFloat(i) / Static.StaticFloat(j))
+        end
+        if i ≥ 0
+            @test sqrt(i) == @inferred(sqrt(Static.StaticInt(i))) == @inferred(sqrt(Static.StaticFloat(i))) == @inferred(sqrt(Static.StaticFloat(Float64(i))))
+        end
+    end
+    @test Static.floortostaticint(1.0) === 1
+    @test Static.floortostaticint(prevfloat(2.0)) === 1
+    @test @inferred(Static.floortostaticint(Static.StaticFloat(1.0))) === Static.StaticInt(1)
+    @test @inferred(Static.floortostaticint(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticInt(1)
+
+    @test Static.roundtostaticint(1.0) === 1
+    @test Static.roundtostaticint(prevfloat(2.0)) === 2
+    @test @inferred(Static.roundtostaticint(Static.StaticFloat(1.0))) === Static.StaticInt(1)
+    @test @inferred(Static.roundtostaticint(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticInt(2)
+    @test @inferred(round(Static.StaticFloat(1.0))) === Static.StaticFloat(1)
+    @test @inferred(round(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticFloat(2)
+end

--- a/test/float.jl
+++ b/test/float.jl
@@ -37,10 +37,12 @@
     @test typeof(fone)(1) isa Static.StaticFloat
     @test typeof(fone)(1.0) isa Static.StaticFloat
 
-    @test @inferred(eltype(Static.StaticFloat(static(1)))) <: Float64
-    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Float64, Int)
+    @test @inferred(eltype(Static.StaticFloat(static(1)))) <: Static.Float
+    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Static.Float, Int)
 
     @test @inferred(inv(static(2.0))) === static(inv(2.0))
+
+    @test @inferred(static(2.0)^2.0) === Static.Float(2.0^2.0)
 
 end
 

--- a/test/float.jl
+++ b/test/float.jl
@@ -1,28 +1,28 @@
 
-@testset "StaticFloat" begin
+@testset "StaticFloat64" begin
     for i ∈ -10:10
         for j ∈ -10:10
-            @test i+j == @inferred(Static.StaticInt(i) + Static.StaticFloat(j)) == @inferred(i + Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) + j) == @inferred(Static.StaticFloat(i) + Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) + Static.StaticFloat(j))
-            @test i-j == @inferred(Static.StaticInt(i) - Static.StaticFloat(j)) == @inferred(i - Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) - Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) - j) == @inferred(Static.StaticFloat(i) - Static.StaticFloat(j))
-            @test i*j == @inferred(Static.StaticInt(i) * Static.StaticFloat(j)) == @inferred(i * Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) * Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) * j) == @inferred(Static.StaticFloat(i) * Static.StaticFloat(j))
+            @test i+j == @inferred(Static.StaticInt(i) + Static.StaticFloat64(j)) == @inferred(i + Static.StaticFloat64(j)) == @inferred(Static.StaticFloat64(i) + j) == @inferred(Static.StaticFloat64(i) + Static.StaticInt(j)) == @inferred(Static.StaticFloat64(i) + Static.StaticFloat64(j))
+            @test i-j == @inferred(Static.StaticInt(i) - Static.StaticFloat64(j)) == @inferred(i - Static.StaticFloat64(j)) == @inferred(Static.StaticFloat64(i) - Static.StaticInt(j)) == @inferred(Static.StaticFloat64(i) - j) == @inferred(Static.StaticFloat64(i) - Static.StaticFloat64(j))
+            @test i*j == @inferred(Static.StaticInt(i) * Static.StaticFloat64(j)) == @inferred(i * Static.StaticFloat64(j)) == @inferred(Static.StaticFloat64(i) * Static.StaticInt(j)) == @inferred(Static.StaticFloat64(i) * j) == @inferred(Static.StaticFloat64(i) * Static.StaticFloat64(j))
             i == j == 0 && continue
-            @test i/j == @inferred(Static.StaticInt(i) / Static.StaticFloat(j)) == @inferred(i / Static.StaticFloat(j)) == @inferred(Static.StaticFloat(i) / Static.StaticInt(j)) == @inferred(Static.StaticFloat(i) / j) == @inferred(Static.StaticFloat(i) / Static.StaticFloat(j))
+            @test i/j == @inferred(Static.StaticInt(i) / Static.StaticFloat64(j)) == @inferred(i / Static.StaticFloat64(j)) == @inferred(Static.StaticFloat64(i) / Static.StaticInt(j)) == @inferred(Static.StaticFloat64(i) / j) == @inferred(Static.StaticFloat64(i) / Static.StaticFloat64(j))
         end
         if i ≥ 0
-            @test sqrt(i) == @inferred(sqrt(Static.StaticInt(i))) == @inferred(sqrt(Static.StaticFloat(i))) == @inferred(sqrt(Static.StaticFloat(Float64(i))))
+            @test sqrt(i) == @inferred(sqrt(Static.StaticInt(i))) == @inferred(sqrt(Static.StaticFloat64(i))) == @inferred(sqrt(Static.StaticFloat64(Float64(i))))
         end
     end
     @test Static.floortostaticint(1.0) === 1
     @test Static.floortostaticint(prevfloat(2.0)) === 1
-    @test @inferred(Static.floortostaticint(Static.StaticFloat(1.0))) === Static.StaticInt(1)
-    @test @inferred(Static.floortostaticint(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticInt(1)
+    @test @inferred(Static.floortostaticint(Static.StaticFloat64(1.0))) === Static.StaticInt(1)
+    @test @inferred(Static.floortostaticint(Static.StaticFloat64(prevfloat(2.0)))) === Static.StaticInt(1)
 
     @test Static.roundtostaticint(1.0) === 1
     @test Static.roundtostaticint(prevfloat(2.0)) === 2
-    @test @inferred(Static.roundtostaticint(Static.StaticFloat(1.0))) === Static.StaticInt(1)
-    @test @inferred(Static.roundtostaticint(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticInt(2)
-    @test @inferred(round(Static.StaticFloat(1.0))) === Static.StaticFloat(1)
-    @test @inferred(round(Static.StaticFloat(prevfloat(2.0)))) === Static.StaticFloat(2)
+    @test @inferred(Static.roundtostaticint(Static.StaticFloat64(1.0))) === Static.StaticInt(1)
+    @test @inferred(Static.roundtostaticint(Static.StaticFloat64(prevfloat(2.0)))) === Static.StaticInt(2)
+    @test @inferred(round(Static.StaticFloat64(1.0))) === Static.StaticFloat64(1)
+    @test @inferred(round(Static.StaticFloat64(prevfloat(2.0)))) === Static.StaticFloat64(2)
 
     fone = static(1.0)
     fzero = static(0.0)
@@ -34,15 +34,18 @@
     @test @inferred(iszero(fzero))
     @test @inferred(iszero(zero(typeof(fzero))))
 
-    @test typeof(fone)(1) isa Static.StaticFloat
-    @test typeof(fone)(1.0) isa Static.StaticFloat
+    @test typeof(fone)(1) isa Static.StaticFloat64
+    @test typeof(fone)(1.0) isa Static.StaticFloat64
 
-    @test @inferred(eltype(Static.StaticFloat(static(1)))) <: Static.Float
-    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Static.Float, Int)
+    @test @inferred(eltype(Static.StaticFloat64(static(1)))) <: Float64
+    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Float64, Int)
+    @test @inferred(promote_type(typeof(fone), Float64)) <: Float64
+    @test @inferred(promote_type(typeof(fone), Float32)) <: Float32
+    @test @inferred(promote_type(typeof(fone), Float16)) <: Float16
 
     @test @inferred(inv(static(2.0))) === static(inv(2.0))
 
-    @test @inferred(static(2.0)^2.0) === Static.Float(2.0^2.0)
+    @test @inferred(static(2.0)^2.0) === 2.0^2.0
 
 end
 

--- a/test/float.jl
+++ b/test/float.jl
@@ -38,10 +38,10 @@
     @test typeof(fone)(1.0) isa Static.StaticFloat64
 
     @test @inferred(eltype(Static.StaticFloat64(static(1)))) <: Float64
-    @test @inferred(promote_type(typeof(fone), Int)) <: promote_type(Float64, Int)
-    @test @inferred(promote_type(typeof(fone), Float64)) <: Float64
-    @test @inferred(promote_type(typeof(fone), Float32)) <: Float32
-    @test @inferred(promote_type(typeof(fone), Float16)) <: Float16
+    @test @inferred(promote_rule(typeof(fone), Int)) <: promote_type(Float64, Int)
+    @test @inferred(promote_rule(typeof(fone), Float64)) <: Float64
+    @test @inferred(promote_rule(typeof(fone), Float32)) <: Float32
+    @test @inferred(promote_rule(typeof(fone), Float16)) <: Float16
 
     @test @inferred(inv(static(2.0))) === static(inv(2.0))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,7 @@ using Test
         @test UnitRange(StaticInt(-11), 15) === -11:15
         @test UnitRange{Int}(StaticInt(-11), StaticInt(15)) === -11:15
         @test UnitRange(StaticInt(-11), StaticInt(15)) === -11:15
-        @test float(StaticInt(8)) === 8.0
+        @test float(StaticInt(8)) === static(8.0)
 
         # test specific promote rules to ensure we don't cause ambiguities
         SI = StaticInt{1}
@@ -258,5 +258,7 @@ x = ntuple(+, 10)
 y = 1:10
 @test @inferred(maybe_static_length(x)) === StaticInt(10)
 @test @inferred(maybe_static_length(y)) === 10
+
+include("float.jl")
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,6 +247,7 @@ using Test
         @test Static.find_first_eq(1, map(Int, y)) === 3
     end
 
+    @test repr(static(float(1))) == "static($(float(1)))"
     @test repr(static(1)) == "static(1)"
     @test repr(static(:x)) == "static(:x)"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,9 +212,11 @@ using Test
         @test @inferred(Static.is_static(typeof(1))) === False()
         @test @inferred(Static.is_static(typeof((static(:x),static(:x))))) === True()
         @test @inferred(Static.is_static(typeof((static(:x),:x)))) === False()
+        @test @inferred(Static.is_static(typeof(static(1.0)))) === True()
 
         @test @inferred(Static.known(typeof(v))) === (:a, 1, true)
         @test @inferred(Static.known(typeof(static(true))))
+        @test @inferred(Static.known(typeof(static(1.0)))) === 1.0
         @test @inferred(Static.known(typeof(static(1)))) === 1
         @test @inferred(Static.known(typeof(static(:x)))) === :x
         @test @inferred(Static.known(typeof(1))) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,23 +195,31 @@ using Test
         @test @inferred(StaticSymbol(x, y, z)) === static(:xy1)
     end
 
-    @testset "static" begin
+    @testset "static interface" begin
+        v = Val((:a, 1, true))
+
         @test static(1) === StaticInt(1)
         @test static(true) === True()
         @test static(:a) === StaticSymbol{:a}()
         @test Symbol(static(:a)) === :a
         @test static((:a, 1, true)) === (static(:a), static(1), static(true))
-        @test @inferred(static(Val((:a, 1, true)))) === (static(:a), static(1), static(true))
+        @test @inferred(static(v)) === (static(:a), static(1), static(true))
         @test_throws ErrorException static("a")
-    end
 
-    @testset "is_static" begin
         @test @inferred(Static.is_static(typeof(static(true)))) === True()
         @test @inferred(Static.is_static(typeof(static(1)))) === True()
         @test @inferred(Static.is_static(typeof(static(:x)))) === True()
         @test @inferred(Static.is_static(typeof(1))) === False()
         @test @inferred(Static.is_static(typeof((static(:x),static(:x))))) === True()
         @test @inferred(Static.is_static(typeof((static(:x),:x)))) === False()
+
+        @test @inferred(Static.known(typeof(v))) === (:a, 1, true)
+        @test @inferred(Static.known(typeof(static(true))))
+        @test @inferred(Static.known(typeof(static(1)))) === 1
+        @test @inferred(Static.known(typeof(static(:x)))) === :x
+        @test @inferred(Static.known(typeof(1))) === nothing
+        @test @inferred(Static.known(typeof((static(:x),static(:x))))) === (:x, :x)
+        @test @inferred(Static.known(typeof((static(:x),:x)))) === (:x, nothing)
     end
 
     @testset "tuple utilities" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,6 +206,8 @@ using Test
         @test @inferred(static(v)) === (static(:a), static(1), static(true))
         @test_throws ErrorException static("a")
 
+        @test @inferred(Static.is_static(v)) === True()
+        @test @inferred(Static.is_static(typeof(v))) === True()
         @test @inferred(Static.is_static(typeof(static(true)))) === True()
         @test @inferred(Static.is_static(typeof(static(1)))) === True()
         @test @inferred(Static.is_static(typeof(static(:x)))) === True()
@@ -214,8 +216,10 @@ using Test
         @test @inferred(Static.is_static(typeof((static(:x),:x)))) === False()
         @test @inferred(Static.is_static(typeof(static(1.0)))) === True()
 
+        @test @inferred(Static.known(v)) === (:a, 1, true)
         @test @inferred(Static.known(typeof(v))) === (:a, 1, true)
         @test @inferred(Static.known(typeof(static(true))))
+        @test @inferred(Static.known(typeof(static(false)))) === false
         @test @inferred(Static.known(typeof(static(1.0)))) === 1.0
         @test @inferred(Static.known(typeof(static(1)))) === 1
         @test @inferred(Static.known(typeof(static(:x)))) === :x


### PR DESCRIPTION
This adds `StaticFloat` which is a static version of `Float64`. Originally I had it follow the behavior of `Int` so that 32 bit systems used `Float32`, but I figured it made more sense to follow the pattern of `float(::Int)` where both `Int32` and `Int64` convert to `Float64`.

Copied test from Octavian.jl for this too.

@DilumAluthge , does this accomplish what you need for Octavian.jl?

~EDIT: Forgot to mention there is an ambiguity issue for 1.2 for `promote_type`. I still need to fix that...~
done