### PR TITLE
Improve bitwise operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.2"
+version = "0.2.1"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -177,16 +177,20 @@ _or(::True, ::False) = True()
 _or(::False, ::True) = True()
 _or(::True, ::True) = True()
 _or(::False, ::False) = False()
-Base.:(|)(x::Bool, y::StaticBool) = x | Bool(y)
-Base.:(|)(x::StaticBool, y::Bool) = Bool(x) | y
+Base.:(|)(x::Bool, y::True) = y
+Base.:(|)(x::Bool, y::False) = x
+Base.:(|)(x::True, y::Bool) = x
+Base.:(|)(x::False, y::Bool) = y
 
 Base.:(&)(x::StaticBool, y::StaticBool) = _and(x, y)
 _and(::True, ::False) = False()
 _and(::False, ::True) = False()
 _and(::True, ::True) = True()
 _and(::False, ::False) = False()
-Base.:(&)(x::Bool, y::StaticBool) = x & Bool(y)
-Base.:(&)(x::StaticBool, y::Bool) = Bool(x) & y
+Base.:(&)(x::Bool, y::True) = x
+Base.:(&)(x::Bool, y::False) = y
+Base.:(&)(x::True, y::Bool) = y
+Base.:(&)(x::False, y::Bool) = x
 
 Base.xor(y::StaticBool, x::StaticBool) = _xor(x, y)
 _xor(::True, ::True) = False()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,14 +104,18 @@ using Test
         @test @inferred(xor(t, t)) === f
 
         @test @inferred(|(true, f))
+        @test @inferred(|(true, t)) === t
         @test @inferred(|(f, true))
+        @test @inferred(|(t, true)) === t
         @test @inferred(|(f, f)) === f
         @test @inferred(|(f, t)) === t
         @test @inferred(|(t, f)) === t
         @test @inferred(|(t, t)) === t
 
-        @test !@inferred(Base.:(&)(true, f))
-        @test !@inferred(Base.:(&)(f, true))
+        @test @inferred(Base.:(&)(true, f)) === f
+        @test @inferred(Base.:(&)(true, t))
+        @test @inferred(Base.:(&)(f, true)) === f
+        @test @inferred(Base.:(&)(t, true))
         @test @inferred(Base.:(&)(f, f)) === f
         @test @inferred(Base.:(&)(f, t)) === f
         @test @inferred(Base.:(&)(t, f)) === f


### PR DESCRIPTION
Correcting a missed opportunity. Now when doing things like `&(::Bool, ::False)` we can return static values b/c it doesn't matter what the first value is.