### PR TITLE
Generalize comparison methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -108,5 +108,4 @@ _dynamic(::True, x::X) where {X} = known(X)
 _dynamic(::False, x::X) where {X} = x
 @aggressive_constprop dynamic(x::Tuple) = map(dynamic, x)
 
-
 end

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -123,7 +123,7 @@ end
     if L === nothing
         return g(x)
     else
-        return StaticInt(L)
+        return static(L)
     end
 end
 
@@ -137,9 +137,7 @@ end
 
 Base.UnitRange(start::StaticInt, stop) = UnitRange(Int(start), stop)
 Base.UnitRange(start, stop::StaticInt) = UnitRange(start, Int(stop))
-function Base.UnitRange(start::StaticInt, stop::StaticInt)
-    return UnitRange(Int(start), Int(stop))
-end
+Base.UnitRange(start::StaticInt, stop::StaticInt) = UnitRange(Int(start), Int(stop))
 
 """
     StaticBool(x::Bool) -> True/False
@@ -258,78 +256,51 @@ Base.any(::Tuple{Vararg{True}}) = true
 Base.any(::Tuple{Vararg{Union{True,False}}}) = true
 Base.any(::Tuple{Vararg{False}}) = false
 
+ifelse(::True, x, y) = x
+
+ifelse(::False, x, y) = y
+
 """
     eq(x::StaticInt, y::StaticInt) -> StaticBool
 
 Equivalent to `==` or `isequal` but returns a `StaticBool`.
 """
-eq(::StaticInt{X}, ::StaticInt{X}) where {X} = True()
-eq(::StaticInt{X}, ::StaticInt{Y}) where {X,Y} = False()
+eq(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x == y)
 
 """
     ne(x::StaticInt, y::StaticInt) -> StaticBool
 
 Equivalent to `!=` but returns a `StaticBool`.
 """
-ne(::StaticInt{X}, ::StaticInt{X}) where {X} = False()
-ne(::StaticInt{X}, ::StaticInt{Y}) where {X,Y} = True()
+ne(x::X, y::Y) where {X,Y} = !eq(x, y)
 
 """
     gt(x::StaticInt, y::StaticInt) -> StaticBool
 
 Equivalent to `>` but returns a `StaticBool`.
 """
-function gt(::StaticInt{X}, ::StaticInt{Y}) where {X,Y}
-    if X > Y
-        return True()
-    else
-        return False()
-    end
-end
+gt(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x > y)
 
 """
     ge(x::StaticInt, y::StaticInt) -> StaticBool
 
 Equivalent to `>=` but returns a `StaticBool`.
 """
-function ge(::StaticInt{X}, ::StaticInt{Y}) where {X,Y}
-    if X >= Y
-        return True()
-    else
-        return False()
-    end
-end
+ge(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x >= y)
 
 """
     le(x::StaticInt, y::StaticInt) -> StaticBool
 
 Equivalent to `<=` but returns a `StaticBool`.
 """
-function le(::StaticInt{X}, ::StaticInt{Y}) where {X,Y}
-    if X <= Y
-        return True()
-    else
-        return False()
-    end
-end
+le(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x <= y)
 
 """
     lt(x::StaticInt, y::StaticInt) -> StaticBool
 
 Equivalent to `<` but returns a `StaticBool`.
 """
-function lt(::StaticInt{X}, ::StaticInt{Y}) where {X,Y}
-    if X < Y
-        return True()
-    else
-        return False()
-    end
-end
-
-ifelse(::True, x, y) = x
-
-ifelse(::False, x, y) = y
-
+lt(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x < y)
 """
     StaticSymbol
 

--- a/src/static_implementation.jl
+++ b/src/static_implementation.jl
@@ -261,46 +261,53 @@ ifelse(::True, x, y) = x
 ifelse(::False, x, y) = y
 
 """
-    eq(x::StaticInt, y::StaticInt) -> StaticBool
+    eq(x, y)
 
-Equivalent to `==` or `isequal` but returns a `StaticBool`.
+Equivalent to `!=` but if `x` and `y` are both static returns a `StaticBool.
 """
 eq(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x == y)
+eq(x::X) where {X} = Base.Fix2(eq, x)
 
 """
-    ne(x::StaticInt, y::StaticInt) -> StaticBool
+    ne(x, y)
 
-Equivalent to `!=` but returns a `StaticBool`.
+Equivalent to `!=` but if `x` and `y` are both static returns a `StaticBool.
 """
 ne(x::X, y::Y) where {X,Y} = !eq(x, y)
+ne(x::X) where {X} = Base.Fix2(ne, x)
 
 """
-    gt(x::StaticInt, y::StaticInt) -> StaticBool
+    gt(x, y)
 
-Equivalent to `>` but returns a `StaticBool`.
+Equivalent to `>` but if `x` and `y` are both static returns a `StaticBool.
 """
 gt(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x > y)
+gt(x::X) where {X} = Base.Fix2(gt, x)
 
 """
-    ge(x::StaticInt, y::StaticInt) -> StaticBool
+    ge(x, y)
 
-Equivalent to `>=` but returns a `StaticBool`.
+Equivalent to `>=` but if `x` and `y` are both static returns a `StaticBool.
 """
 ge(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x >= y)
+ge(x::X) where {X} = Base.Fix2(ge, x)
 
 """
-    le(x::StaticInt, y::StaticInt) -> StaticBool
+    le(x, y)
 
-Equivalent to `<=` but returns a `StaticBool`.
+Equivalent to `<=` but if `x` and `y` are both static returns a `StaticBool.
 """
 le(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x <= y)
+le(x::X) where {X} = Base.Fix2(le, x)
 
 """
-    lt(x::StaticInt, y::StaticInt) -> StaticBool
+    lt(x, y)
 
-Equivalent to `<` but returns a `StaticBool`.
+Equivalent to `<` but if `x` and `y` are both static returns a `StaticBool.
 """
 lt(x::X, y::Y) where {X,Y} = ifelse(is_static(X) & is_static(Y), static, identity)(x < y)
+lt(x::X) where {X} = Base.Fix2(lt, x)
+
 """
     StaticSymbol
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,22 +162,22 @@ using Test
         x = StaticInt(1)
         y = StaticInt(0)
         z = StaticInt(-1)
-        @test @inferred(Static.eq(x, y)) === f
+        @test @inferred(Static.eq(x)(y)) === f
         @test @inferred(Static.eq(x, x)) === t
 
-        @test @inferred(Static.ne(x, y)) === t
+        @test @inferred(Static.ne(x)(y)) === t
         @test @inferred(Static.ne(x, x)) === f
 
-        @test @inferred(Static.gt(x, y)) === t
+        @test @inferred(Static.gt(x)(y)) === t
         @test @inferred(Static.gt(y, x)) === f
 
-        @test @inferred(Static.ge(x, y)) === t
+        @test @inferred(Static.ge(x)(y)) === t
         @test @inferred(Static.ge(y, x)) === f
 
-        @test @inferred(Static.lt(y, x)) === t
+        @test @inferred(Static.lt(y)(x)) === t
         @test @inferred(Static.lt(x, y)) === f
 
-        @test @inferred(Static.le(y, x)) === t
+        @test @inferred(Static.le(y)(x)) === t
         @test @inferred(Static.le(x, y)) === f
 
         @test @inferred(Static.ifelse(t, x, y)) === x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,22 +162,22 @@ using Test
         x = StaticInt(1)
         y = StaticInt(0)
         z = StaticInt(-1)
-        @test @inferred(Static.eq(x)(y)) === f
+        @test @inferred(Static.eq(y)(x)) === f
         @test @inferred(Static.eq(x, x)) === t
 
-        @test @inferred(Static.ne(x)(y)) === t
+        @test @inferred(Static.ne(y)(x)) === t
         @test @inferred(Static.ne(x, x)) === f
 
-        @test @inferred(Static.gt(x)(y)) === t
+        @test @inferred(Static.gt(y)(x)) === t
         @test @inferred(Static.gt(y, x)) === f
 
-        @test @inferred(Static.ge(x)(y)) === t
+        @test @inferred(Static.ge(y)(x)) === t
         @test @inferred(Static.ge(y, x)) === f
 
-        @test @inferred(Static.lt(y)(x)) === t
+        @test @inferred(Static.lt(x)(y)) === t
         @test @inferred(Static.lt(x, y)) === f
 
-        @test @inferred(Static.le(y)(x)) === t
+        @test @inferred(Static.le(x)(y)) === t
         @test @inferred(Static.le(x, y)) === f
 
         @test @inferred(Static.ifelse(t, x, y)) === x


### PR DESCRIPTION
We have `StaticFloat64` so `gt`/`eq`/etc are useful outside of `StaticInt`. These changes also support any additional future static types that may come around by using `is_static`. That way downstream packages can define their own static types and get all the same optimized functions working.