### PR TITLE
Promote smaller integer types for `static`

### DIFF
--- a/src/Static.jl
+++ b/src/Static.jl
@@ -65,6 +65,10 @@ static(:x)
 static
 @aggressive_constprop static(x::X) where {X} = ifelse(is_static(X), identity, _no_static_type)(x)
 @aggressive_constprop static(x::Int) = StaticInt(x)
+@aggressive_constprop static(x::Union{Int8,UInt8,Int16,UInt16}) = StaticInt(x % Int)
+if sizeof(Int) == 8
+    @aggressive_constprop static(x::Union{Int32,UInt32}) = StaticInt(x % Int)
+end
 @aggressive_constprop static(x::Float64) = StaticFloat64(x)
 @aggressive_constprop static(x::Bool) = StaticBool(x)
 @aggressive_constprop static(x::Symbol) = StaticSymbol(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,15 @@ using Test
         @test @inferred(promote_rule(Union{Nothing,Missing}, SI)) <: promote_type(Union{Nothing,Missing}, Int)
         @test @inferred(promote_rule(SI, Missing)) <: promote_type(Int, Missing)
         @test @inferred(promote_rule(Base.TwicePrecision{Int}, StaticInt{1})) <: Base.TwicePrecision{Int}
+
+        @test static(Int8(-18)) === static(-18)
+        @test static(0xef) === static(239)
+        @test static(Int16(-18)) === static(-18)
+        @test static(0xffef) === static(65519)
+        if sizeof(Int) == 8
+            @test static(Int32(-18)) === static(-18)
+            @test static(0xffffffef) === static(4294967279)
+        end
     end
 
     @testset "StaticBool" begin


### PR DESCRIPTION
The motivation, before::
```julia
julia> ArrayInterface.static_step(Int32(-10):Int32(10))
ERROR: There is no static alternative for type Int32.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] _no_static_type(x::Any)
   @ Static ~/.julia/packages/Static/I7z33/src/Static.jl:74
 [3] static(x::Int32)
   @ Static ~/.julia/packages/Static/I7z33/src/Static.jl:66
 [4] maybe_static
   @ ~/.julia/packages/Static/I7z33/src/static_implementation.jl:126 [inlined]
 [5] static_step(x::UnitRange{Int32})
   @ ArrayInterface ~/.julia/packages/ArrayInterface/CiK9Q/src/ArrayInterface.jl:42
 [6] top-level scope
   @ REPL[11]:1
```
After:
```julia
julia> ArrayInterface.static_step(Int32(-10):Int32(10))
static(1)
```
Perhaps I should just call `convert` instead of using `%`, as half of `UInt`s (for example) are representable by `Int`.