### PR TITLE
Nospecialize on dynamic pairs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -30,11 +30,12 @@ Returns the known value corresponding to a static type `T`. If `T` is not a stat
 See also: [`static`](@ref), [`is_static`](@ref)
 """
 known
-@constprop :aggressive known(x) = known(typeof(x))
+#@constprop :aggressive known(x) = known(typeof(x))
+known(@nospecialize(x)) = known(typeof(x))
 known(::Type{T}) where {T} = nothing
-known(::Type{StaticInt{N}}) where {N} = N::Int
-known(::Type{StaticFloat64{N}}) where {N} = N::Float64
-known(::Type{StaticSymbol{S}}) where {S} = S::Symbol
+known(@nospecialize(x::Type{<:StaticInt}))::Int = @inbounds(getfield(x, :parameters)[1])
+known(@nospecialize(x::Type{<:StaticSymbol}))::Symbol = @inbounds(getfield(x, :parameters)[1])
+known(@nospecialize(x::Type{<:StaticFloat64}))::Float64 = @inbounds(getfield(x, :parameters)[1])
 known(::Type{Val{V}}) where {V} = V
 known(::Type{True}) = true
 known(::Type{False}) = false
@@ -116,9 +117,9 @@ end
 
 Returns the "dynamic" or non-static form of `x`.
 """
-dynamic(x::X) where {X} = _dynamic(is_static(X), x)
-_dynamic(::True, x::X) where {X} = known(X)
-_dynamic(::False, x::X) where {X} = x
+dynamic(@nospecialize(x)) = _dynamic(is_static(x), x)
+_dynamic(::True, @nospecialize(x)) = known(typeof(x))
+_dynamic(::False, x) = x
 @constprop :aggressive dynamic(x::Tuple) = map(dynamic, x)
 dynamic(x::NDIndex) = CartesianIndex(dynamic(Tuple(x)))
 

--- a/src/bool.jl
+++ b/src/bool.jl
@@ -126,5 +126,5 @@ ifelse(::True, x, y) = x
 
 ifelse(::False, x, y) = y
 
-Base.show(io::IO, ::StaticBool{bool}) where {bool} = print(io, "static($bool)")
+Base.show(io::IO, @nospecialize(x::StaticBool)) = print(io, "static($(dynamic(x)))")
 

--- a/src/float.jl
+++ b/src/float.jl
@@ -24,7 +24,7 @@ const FloatZero = StaticFloat64{zero(Float64)}
 Base.show(io::IO, @nospecialize(x::StaticFloat64)) = print(io, "static($(dynamic(x)))")
 
 Base.convert(::Type{T}, @nospecialize(x::StaticFloat64)) where {T<:AbstractFloat} = T(dynamic(x))
-Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{T}) where {T} = promote_type(T, Float64)
+Base.promote_rule(x::Type{<:StaticFloat64}, ::Type{T}) where {T} = promote_type(T, Float64)
 Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float64})  = Float64
 Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float32}) = Float32
 Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float16}) = Float16

--- a/src/float.jl
+++ b/src/float.jl
@@ -24,7 +24,7 @@ const FloatZero = StaticFloat64{zero(Float64)}
 Base.show(io::IO, @nospecialize(x::StaticFloat64)) = print(io, "static($(dynamic(x)))")
 
 Base.convert(::Type{T}, @nospecialize(x::StaticFloat64)) where {T<:AbstractFloat} = T(dynamic(x))
-Base.promote_rule(x::Type{<:StaticFloat64}, ::Type{T}) where {T} = promote_type(T, Float64)
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{T}) where {N,T} = promote_type(T, Float64)
 Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float64})  = Float64
 Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float32}) = Float32
 Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float16}) = Float16

--- a/src/float.jl
+++ b/src/float.jl
@@ -21,25 +21,25 @@ StaticFloat64(x::StaticInt{N}) where {N} = float(x)
 const FloatOne = StaticFloat64{one(Float64)}
 const FloatZero = StaticFloat64{zero(Float64)}
 
-Base.show(io::IO, ::StaticFloat64{N}) where {N} = print(io, "static($N)")
+Base.show(io::IO, @nospecialize(x::StaticFloat64)) = print(io, "static($(dynamic(x)))")
 
-Base.convert(::Type{T}, ::StaticFloat64{N}) where {N,T<:AbstractFloat} = T(N)
-Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{T}) where {N,T} = promote_type(T, Float64)
-Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float64}) where {N} = Float64
-Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float32}) where {N} = Float32
-Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float16}) where {N} = Float16
+Base.convert(::Type{T}, @nospecialize(x::StaticFloat64)) where {T<:AbstractFloat} = T(dynamic(x))
+Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{T}) where {T} = promote_type(T, Float64)
+Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float64})  = Float64
+Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float32}) = Float32
+Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float16}) = Float16
 
 @static if VERSION == v"1.2"
     Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Any}) where {N} = Any
 end
 
-Base.eltype(::Type{T}) where {T<:StaticFloat64} = Float64
+Base.eltype(@nospecialize(x::Type{<:StaticFloat64})) = Float64
 Base.iszero(::FloatZero) = true
-Base.iszero(::StaticFloat64) = false
+Base.iszero(@nospecialize(x::StaticFloat64)) = false
 Base.isone(::FloatOne) = true
-Base.isone(::StaticFloat64) = false
-Base.zero(::Type{T}) where {T<:StaticFloat64} = FloatZero()
-Base.one(::Type{T}) where {T<:StaticFloat64} = FloatOne()
+Base.isone(@nospecialize(x::StaticFloat64)) = false
+Base.zero(@nospecialize(x::Type{<:StaticFloat64})) = FloatZero()
+Base.one(@nospecialize(x::Type{<:StaticFloat64})) = FloatOne()
 
 Base.@pure function fsub(::StaticFloat64{X}, ::StaticFloat64{Y}) where {X,Y}
     return StaticFloat64{Base.sub_float(X, Y)::Float64}()

--- a/src/float.jl
+++ b/src/float.jl
@@ -25,9 +25,9 @@ Base.show(io::IO, @nospecialize(x::StaticFloat64)) = print(io, "static($(dynamic
 
 Base.convert(::Type{T}, @nospecialize(x::StaticFloat64)) where {T<:AbstractFloat} = T(dynamic(x))
 Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{T}) where {N,T} = promote_type(T, Float64)
-Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float64})  = Float64
-Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float32}) = Float32
-Base.promote_rule(@nospecialize(x::Type{<:StaticFloat64}), ::Type{Float16}) = Float16
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float64}) where {N} = Float64
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float32}) where {N} = Float32
+Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float16}) where {N} = Float16
 
 @static if VERSION == v"1.2"
     Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Any}) where {N} = Any

--- a/src/symbol.jl
+++ b/src/symbol.jl
@@ -19,5 +19,5 @@ StaticSymbol(x, y, z...) = StaticSymbol(StaticSymbol(x, y), z...)
 
 Base.Symbol(::StaticSymbol{s}) where {s} = s::Symbol
 
-Base.show(io::IO, ::StaticSymbol{s}) where {s} = print(io, "static(:$s)")
+Base.show(io::IO, @nospecialize(x::StaticSymbol)) = print(io, "static(:$(dynamic(x)))")
 


### PR DESCRIPTION
There shouldn't be any changes to code inference. This does more of what #13 does but focuses on methods where one argument is static and one is dynamic, making it unnecessary to specialize on the static type. 

@chriselrod, if this doesn't affect performance or constant propagation for your code libraries then it should be good to go.