### PR TITLE
add floating point ops from Base

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/float.jl
+++ b/src/float.jl
@@ -109,3 +109,20 @@ Base.:(^)(::StaticFloat64{x}, y::Float64) where {x} = exp2(log2(x) * y)
 
 Base.inv(x::StaticFloat64{N}) where {N} = fdiv(one(x), x)
 
+# @generated function Base.exponent(::StaticFloat64{M}) where {M}
+#     Expr(:call, Expr(:curly, :StaticInt, exponent(M)))
+# end
+
+@inline function Base.exponent(::StaticFloat64{M}) where {M}
+    static(exponent(M))
+end
+
+for f in (:sin, :cos, :tan, :asin, :atan, :acos,
+    :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
+    :exp, :exp2, :exp10, :expm1, :log, :log2, :log10, :log1p,
+    :cbrt)
+
+    @eval @generated function (Base.$f)(::StaticFloat64{M}) where {M}
+        Expr(:call, Expr(:curly, :StaticFloat64, $f(M)))
+    end
+end

--- a/test/float.jl
+++ b/test/float.jl
@@ -47,5 +47,15 @@
 
     @test @inferred(static(2.0)^2.0) === 2.0^2.0
 
+    for f in (:sin, :cos, :tan, :asin, :atan, :acos,
+        :sinh, :cosh, :tanh, :asinh, :atanh,
+        :exp, :exp2, :exp10, :expm1, :log, :log2, :log10, :log1p,
+        :exponent, :sqrt, :cbrt)
+        @info "Testing $f(0.5)"
+        @eval @inferred $f(static(.5))
+    end
+
+    @info "Testing acosh(1.5)"
+    @inferred acosh(static(1.5))
 end
 

--- a/test/float.jl
+++ b/test/float.jl
@@ -47,12 +47,12 @@
 
     @test @inferred(static(2.0)^2.0) === 2.0^2.0
 
-    for f in (:sin, :cos, :tan, :asin, :atan, :acos,
-        :sinh, :cosh, :tanh, :asinh, :atanh,
-        :exp, :exp2, :exp10, :expm1, :log, :log2, :log10, :log1p,
-        :exponent, :sqrt, :cbrt)
+    for f in (sin, cos, tan, asin, atan, acos,
+        sinh, cosh, tanh, asinh, atanh,
+        exp, exp2, exp10, expm1, log, log2, log10, log1p,
+        exponent, sqrt, cbrt)
         @info "Testing $f(0.5)"
-        @eval @inferred $f(static(.5))
+        @inferred f(static(.5))
     end
 
     @info "Testing acosh(1.5)"


### PR DESCRIPTION
This PR adds the lines
```julia

@inline function Base.exponent(::StaticFloat64{M}) where {M}
    static(exponent(M))
end

for f in (:sin, :cos, :tan, :asin, :atan, :acos,
    :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
    :exp, :exp2, :exp10, :expm1, :log, :log2, :log10, :log1p,
    :cbrt)

    @eval @generated function (Base.$f)(::StaticFloat64{M}) where {M}
        Expr(:call, Expr(:curly, :StaticFloat64, $f(M)))
    end
end
```

and relevant tests. Closes https://github.com/SciML/Static.jl/issues/31