### PR TITLE
Fix `find_first_eq`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/tuples.jl
+++ b/src/tuples.jl
@@ -73,6 +73,8 @@ If `x` and `collection` are static (`is_static`) and `x` is in `collection` then
 value is a `StaticInt`.
 =#
 @generated function find_first_eq(x::X, itr::I) where {X,N,I<:Tuple{Vararg{Any,N}}}
+    # we avoid incidental code gen when evaluated a tuple of known values by iterating
+    #  through `I.parameters` instead of `known(I)`.
     index = ifelse(known(X) === missing, nothing, findfirst(==(X), I.parameters))
     if index === nothing
         :(Base.Cartesian.@nif $(N + 1) d->(x == getfield(itr, d)) d->(d) d->(nothing))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -296,13 +296,14 @@ using Test
         @test @inferred(Static.permute(x, y)) === y
         @test @inferred(Static.eachop(getindex, x)) === x
 
-        
         @test Static.field_type(typeof((x = 1, y = 2)), :x) <: Int
         @test Static.field_type(typeof((x = 1, y = 2)), static(:x)) <: Int
         get_tuple_add(::Type{T}, ::Type{X}, dim::StaticInt) where {T,X} = Tuple{Static.field_type(T, dim),X}
         @test @inferred(Static.eachop_tuple(Static.field_type, y, T)) === Tuple{String,Float64,Int}
         @test @inferred(Static.eachop_tuple(get_tuple_add, y, T, String)) === Tuple{Tuple{String,String},Tuple{Float64,String},Tuple{Int,String}}
         @test @inferred(Static.find_first_eq(static(1), y)) === static(3)
+        @test @inferred(Static.find_first_eq(static(2), (1, static(2)))) === static(2)
+        @test @inferred(Static.find_first_eq(static(2), (1, static(2), 3))) === static(2)
         # inferred is Union{Int,Nothing}
         @test Static.find_first_eq(1, map(Int, y)) === 3
 


### PR DESCRIPTION
When I first wrote this method it used `===` to evaluate equality after testing if the collection was static or not. Consequently, mixed dynamic/static collections would miss values that were `==` but not `===`. This now works and has additional tests for that.