### PR TITLE
Fixe `==` for symbols

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/symbol.jl
+++ b/src/symbol.jl
@@ -21,7 +21,7 @@ Base.Symbol(::StaticSymbol{s}) where {s} = s::Symbol
 
 Base.:(==)(::StaticSymbol{X}, ::StaticSymbol{Y}) where {X,Y} = X === Y
 Base.:(==)(@nospecialize(x::StaticSymbol), y::Symbol) = dynamic(x) === y
-Base.:(==)(x::Symbol, @nospecialize(y::StaticSymbol)) = x === dynamic(x)
+Base.:(==)(x::Symbol, @nospecialize(y::StaticSymbol)) = x === dynamic(y)
 
 Base.show(io::IO, ::StaticSymbol{s}) where {s} = print(io, "static(:$s)")
 


### PR DESCRIPTION
previously was comparing x to x instead of x to y