### PR TITLE
Fix recursion to zero length eachop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/tuples.jl
+++ b/src/tuples.jl
@@ -34,12 +34,10 @@ end
 
 Produces a tuple of `(op(args..., iterator[1]), op(args..., iterator[2]),...)`.
 """
-@inline function eachop(op::F, itr::Tuple{I1,I2,Vararg}, args::Vararg{Any,K}) where {F,I1,I2,K}
+@inline function eachop(op::F, itr::Tuple{T,Vararg{Any}}, args::Vararg{Any}) where {F,T}
     return (op(args..., first(itr)), eachop(op, Base.tail(itr), args...)...)
 end
-@inline function eachop(op::F, itr::Tuple{I}, args::Vararg{Any,K}) where {F,I,K}
-    return (op(args..., first(itr)),)
-end
+eachop(::F, ::Tuple{}, args::Vararg{Any}) where {F} = ()
 
 """
     eachop_tuple(op, arg, args...; iterator::Tuple{Vararg{StaticInt}}) -> Type{Tuple}


### PR DESCRIPTION
While updating LoopVectorization I found the need to account for empty tuples on `eachop`.