### PR TITLE
Support nothings in static checks

### DIFF
--- a/src/int.jl
+++ b/src/int.jl
@@ -119,7 +119,7 @@ end
 
 @inline function maybe_static(f::F, g::G, x) where {F,G}
     L = f(x)
-    if L === missing
+    if L === missing || L === nothing
         return g(x)
     else
         return static(L)


### PR DESCRIPTION
I don't see a reason to not just support both in this check?