### PR TITLE
Revert "Return `missing` instead of `nothing`." and adjust find_first_eq

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.5.6"
+version = "0.6.0"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -26,13 +26,13 @@ include("tuples.jl")
     known(::Type{T})
 
 Returns the known value corresponding to a static type `T`. If `T` is not a static type then
-`missing` is returned.
+`nothing` is returned.
 
 See also: [`static`](@ref), [`is_static`](@ref)
 """
 known
 @constprop :aggressive known(x) = known(typeof(x))
-known(::Type{T}) where {T} = missing
+known(::Type{T}) where {T} = nothing
 known(::Type{StaticInt{N}}) where {N} = N::Int
 known(::Type{StaticFloat64{N}}) where {N} = N::Float64
 known(::Type{StaticSymbol{S}}) where {S} = S::Symbol

--- a/src/int.jl
+++ b/src/int.jl
@@ -119,7 +119,7 @@ end
 
 @inline function maybe_static(f::F, g::G, x) where {F,G}
     L = f(x)
-    if L === missing
+    if L === nothing
         return g(x)
     else
         return static(L)

--- a/src/tuples.jl
+++ b/src/tuples.jl
@@ -73,7 +73,7 @@ value is a `StaticInt`.
 @generated function find_first_eq(x::X, itr::I) where {X,N,I<:Tuple{Vararg{Any,N}}}
     # we avoid incidental code gen when evaluated a tuple of known values by iterating
     #  through `I.parameters` instead of `known(I)`.
-    index = ifelse(known(X) === missing, nothing, findfirst(==(X), I.parameters))
+    index = ifelse(known(X) === nothing, nothing, findfirst(==(X), I.parameters))
     if index === nothing
         :(Base.Cartesian.@nif $(N + 1) d->(x == getfield(itr, d)) d->(d) d->(nothing))
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -274,9 +274,9 @@ using Test
         @test @inferred(Static.known(typeof(static(1.0)))) === 1.0
         @test @inferred(Static.known(typeof(static(1)))) === 1
         @test @inferred(Static.known(typeof(static(:x)))) === :x
-        @test @inferred(Static.known(typeof(1))) === missing
+        @test @inferred(Static.known(typeof(1))) === nothing
         @test @inferred(Static.known(typeof((static(:x),static(:x))))) === (:x, :x)
-        @test @inferred(Static.known(typeof((static(:x),:x)))) === (:x, missing)
+        @test @inferred(Static.known(typeof((static(:x),:x)))) === (:x, nothing)
 
         @test @inferred(Static.dynamic((static(:a), static(1), true))) === (:a, 1, true)
     end
@@ -369,7 +369,7 @@ end
 # for some reason this can't be inferred when in the "Static.jl" test set
 known_length(x) = known_length(typeof(x))
 known_length(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}} = N
-known_length(::Type{T}) where {T} = missing
+known_length(::Type{T}) where {T} = nothing
 maybe_static_length(x) = Static.maybe_static(known_length, length, x)
 x = ntuple(+, 10)
 y = 1:10


### PR DESCRIPTION
This reverts commit 63b791b1e602b6cefe598c46bd306b861397828a.
This reverts commit f854a705fbf7ef7db4535ea1503b0c2bad6b491a.
This reverts commit ca7f1edbfc60dba22ee2f538ca22ca9826c07099.

Let's see who wins the race.