### PR TITLE
Fix symbol printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -129,8 +129,10 @@ dynamic(x::NDIndex) = CartesianIndex(dynamic(Tuple(x)))
 for T in [StaticInt, StaticFloat64, StaticBool, StaticSymbol]
     @eval begin
         function Base.string(@nospecialize(x::$(T)); kwargs...)
-            string("static(" * string(dynamic(x)) * ")"; kwargs...)
+            string("static(" * repr(known(typeof(x))) * ")"; kwargs...)
         end
+        Base.show(io::IO, @nospecialize(x::$(T))) = show(io, MIME"text/plain"(), x)
+        Base.show(io::IO, ::MIME"text/plain", @nospecialize(x::$(T))) = print(io, string(x))
     end
 end
 

--- a/src/bool.jl
+++ b/src/bool.jl
@@ -124,5 +124,3 @@ ifelse(::True, x, y) = x
 
 ifelse(::False, x, y) = y
 
-Base.show(io::IO, ::StaticBool{bool}) where {bool} = print(io, "static($bool)")
-

--- a/src/float.jl
+++ b/src/float.jl
@@ -21,17 +21,11 @@ StaticFloat64(x::StaticInt{N}) where {N} = float(x)
 const FloatOne = StaticFloat64{one(Float64)}
 const FloatZero = StaticFloat64{zero(Float64)}
 
-Base.show(io::IO, ::StaticFloat64{N}) where {N} = print(io, "static($N)")
-
 Base.convert(::Type{T}, ::StaticFloat64{N}) where {N,T<:AbstractFloat} = T(N)
 Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{T}) where {N,T} = promote_type(T, Float64)
 Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float64}) where {N} = Float64
 Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float32}) where {N} = Float32
 Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Float16}) where {N} = Float16
-
-@static if VERSION == v"1.2"
-    Base.promote_rule(::Type{StaticFloat64{N}}, ::Type{Any}) where {N} = Any
-end
 
 Base.eltype(::Type{T}) where {T<:StaticFloat64} = Float64
 Base.iszero(::FloatZero) = true

--- a/src/int.jl
+++ b/src/int.jl
@@ -12,8 +12,6 @@ end
 const Zero = StaticInt{0}
 const One = StaticInt{1}
 
-Base.show(io::IO, ::StaticInt{N}) where {N} = print(io, "static($N)")
-
 StaticInt(N::Int) = StaticInt{N}()
 StaticInt(N::Integer) = StaticInt(convert(Int, N))
 StaticInt(::StaticInt{N}) where {N} = StaticInt{N}()

--- a/src/symbol.jl
+++ b/src/symbol.jl
@@ -23,5 +23,3 @@ Base.:(==)(::StaticSymbol{X}, ::StaticSymbol{Y}) where {X,Y} = X === Y
 Base.:(==)(@nospecialize(x::StaticSymbol), y::Symbol) = dynamic(x) === y
 Base.:(==)(x::Symbol, @nospecialize(y::StaticSymbol)) = x === dynamic(y)
 
-Base.show(io::IO, ::StaticSymbol{s}) where {s} = print(io, "static(:$s)")
-


### PR DESCRIPTION
* `string(::Symbol)` drops the `:` precursor, but we want that shown for
  `static(::Symbol)`. Now all show methods go through `string` for consistency.
* Deleted Julia v1.2 specific method b/c we don't support prior to Julia
  v1.6 anymore