### PR TITLE
Propagate static(0) * x

### DIFF
--- a/src/float.jl
+++ b/src/float.jl
@@ -61,6 +61,8 @@ Base.:-(@nospecialize(x::StaticFloat64), @nospecialize(y::StaticFloat64)) = fsub
 Base.:*(@nospecialize(x::StaticFloat64), @nospecialize(y::StaticFloat64)) = fmul(x, y)
 @inline Base.:*(@nospecialize(x::StaticFloat64), @nospecialize(y::StaticInt)) = *(x, float(y))
 @inline Base.:*(@nospecialize(x::StaticInt), @nospecialize(y::StaticFloat64)) = *(float(x), y)
+@inline Base.:*(@nospecialize(x::StaticFloat64), ::Zero) = FloatZero()
+@inline Base.:*(::Zero, @nospecialize(y::StaticFloat64)) = FloatZero()
 
 Base.:/(@nospecialize(x::StaticFloat64), @nospecialize(y::StaticFloat64)) = fdiv(x, y)
 Base.:/(@nospecialize(x::StaticFloat64), @nospecialize(y::StaticInt)) = /(x, float(y))

--- a/src/int.jl
+++ b/src/int.jl
@@ -56,6 +56,7 @@ Base.isone(@nospecialize(x::StaticInt)) = false
 Base.zero(@nospecialize(x::Type{<:StaticInt})) = Zero()
 Base.one(@nospecialize(x::Type{<:StaticInt})) = One()
 
+
 for T in [:Real, :Rational, :Integer]
     for f in [:(-), :(+), :(*)]
         @eval begin
@@ -63,12 +64,21 @@ for T in [:Real, :Rational, :Integer]
             Base.$(f)(@nospecialize(x::StaticInt), y::$T) = $(f)(Int(x), y)
         end
     end
+    @eval begin
+        Base.:(*)(::$T, ::Zero) = Zero()
+        Base.:(*)(::Zero, ::$T) = Zero()
+    end
 end
+Base.:(*)(@nospecialize(x::StaticInt), ::Zero) = Zero()
+Base.:(*)(::Zero, @nospecialize(y::StaticInt)) = Zero()
+Base.:(*)(::Zero, ::Zero) = Zero()
+
 @inline Base.:(-)(::StaticInt{M}) where {M} = StaticInt{-M}()
 
 for f in [:(+), :(-), :(*), :(÷), :(%), :(<<), :(>>), :(>>>), :(&), :(|), :(⊻)]
     eval(:(Base.$f(::StaticInt{M}, ::StaticInt{N}) where {M,N} = StaticInt{$f(M,N)}()))
 end
+
 for f in [:(<<), :(>>), :(>>>)]
     @eval begin
         Base.$f(@nospecialize(x::StaticInt), y::UInt) = $f(Int(x), y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Static, Aqua
+using Static: Zero
 using Test
 
 @testset "Static.jl" begin
@@ -43,6 +44,7 @@ using Test
                 @test convert(typeof(z), @inferred(f(2 // 7, i))) === z 
             end
         end
+        @test @inferred(*(Zero(), 3)) === @inferred(*(3, Zero())) === *(Zero(), Zero())
 
         @test UnitRange{Int16}(StaticInt(-9), 17) === Int16(-9):Int16(17)
         @test UnitRange{Int16}(-7, StaticInt(19)) === Int16(-7):Int16(19)


### PR DESCRIPTION
Reverts to prior behavior and fixes #58. @chriselrod, It seems like we should only return `StaicInt{0}` when multiplied with other integers because we should promote. Would that break anything on your end?