### PR TITLE
`StaticInt` support for `ntuple`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.7"
+version = "0.7.1"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -485,8 +485,7 @@ Base.:(^)(x::BigInt, y::True) = x
     (N >= 0) || throw(ArgumentError(string("tuple length should be ≥ 0, got ", N)))
     if @generated
         quote
-            Base.Cartesian.@nexprs $N i -> t_i = f(i)
-            Base.Cartesian.@ncall $N tuple t
+            Base.Cartesian.@ntuple $N i -> f(i)
         end
     else
         Tuple(f(i) for i = 1:N)


### PR DESCRIPTION
I found that many test failures in VectorizationBase on Static v0.7 were due to `StaticInt` not being an integer when passed to `ntuple(f, ::StaticInt)`. I tested load times here and didn't see any consistent increase due to the additional method here and there were no additional invalidations.