### PR TITLE
static-invperm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -590,8 +590,8 @@ value is a `StaticInt`.
     end
 end
 
-function Base.invperm(p::Tuple{Vararg{StaticInt,N}}) where {N}
-    map(Base.Fix2(find_first_eq, p), ntuple(static, StaticInt(N)))
+function Base.invperm(p::Tuple{StaticInt,Vararg{StaticInt,N}}) where {N}
+    map(Base.Fix2(find_first_eq, p), ntuple(static, StaticInt(N + 1)))
 end
 
 """

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -210,7 +210,10 @@ static(x::Union{Symbol, AbstractChar, AbstractString}) = StaticSymbol(x)
 static(x::Tuple{Vararg{Any}}) = map(static, x)
 static(::Val{V}) where {V} = static(V)
 static(x::CartesianIndex) = NDIndex(static(Tuple(x)))
-@noinline static(x) = error("There is no static alternative for type $(typeof(x)).")
+function static(x::X) where {X}
+    Base.issingletontype(X) && return x
+    error("There is no static alternative for type $(typeof(x)).")
+end
 
 """
     is_static(::Type{T}) -> StaticBool
@@ -585,6 +588,10 @@ value is a `StaticInt`.
     else
         :($(static(index)))
     end
+end
+
+function Base.invperm(p::Tuple{Vararg{StaticInt,N}}) where {N}
+    map(Base.Fix2(find_first_eq, p), ntuple(static, StaticInt(N)))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ Aqua.test_all(Static)
     @test @inferred(StaticSymbol(x)) === x
     @test @inferred(StaticSymbol(x, y)) === StaticSymbol(:x, :y)
     @test @inferred(StaticSymbol(x, y, z)) === static(:xy1)
+    @test @inferred(static(nothing)) === nothing
     @test_throws ErrorException static([])
 end
 
@@ -328,6 +329,12 @@ end
                    n)
         @test @inferred(Static.reduce_tup(+, x)) ≈ reduce(+, x)
     end end
+end
+
+@testset "invperm" begin
+    perm = static((10, 3, 4, 5, 6, 2, 9, 7, 8, 1))
+    invp = static((10, 6, 2, 3, 4, 5, 8, 9, 7, 1))
+    @test @inferred(invperm(perm)) === invp
 end
 
 @testset "NDIndex" begin


### PR DESCRIPTION
Supports `invperm` for tuple of `StaticInt`. This also allows `static(x)` to simply return `x` if it is a singleton type, instead of erroring.