### PR TITLE
Remove invalidating `!` overloads

### DIFF
--- a/src/Static.jl
+++ b/src/Static.jl
@@ -423,8 +423,9 @@ Base.xor(::StaticInteger{X}, ::StaticInteger{Y}) where {X, Y} = static(xor(X, Y)
 Base.xor(::StaticInteger{X}, y::Union{Integer, Missing}) where {X} = xor(X, y)
 Base.xor(x::Union{Integer, Missing}, ::StaticInteger{Y}) where {Y} = xor(x, Y)
 
-Base.:(!)(::True) = False()
-Base.:(!)(::False) = True()
+# These are heavily invalidating, leading to major compile time increases downstream
+#Base.:(!)(::True) = False()
+#Base.:(!)(::False) = True()
 
 Base.all(::Tuple{Vararg{True}}) = true
 Base.all(::Tuple{Vararg{Union{True, False}}}) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,8 +117,6 @@ end
 
     @test @inferred(~t) === f
     @test @inferred(~f) === t
-    @test @inferred(!t) === f
-    @test @inferred(!f) === t
     @test @inferred(+t) === StaticInt(1)
     @test @inferred(+f) === StaticInt(0)
     @test @inferred(-t) === StaticInt(-1)


### PR DESCRIPTION
Running things downstream, life seems to go on without them just fine. Found in https://github.com/SciML/DifferentialEquations.jl/issues/786 and https://github.com/SciML/Static.jl/issues/77, these methods contribute to a ton of recompilation. Methods that cause lots of compilation but aren't used? Bye bye.

Users of Static.jl can just manually handle `!`. It's safe because it just throws an error otherwise. We can put it in an FAQ if it's that much of an issue. But this is definitely not worth causing seconds of JIT lag downstream.