### PR TITLE
More informative README (issue #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,29 @@
 [![Build Status](https://github.com/SciML/Static.jl/workflows/CI/badge.svg)](https://github.com/SciML/Static.jl/actions)
 [![Coverage](https://codecov.io/gh/SciML/Static.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/Static.jl)
 
-`Static` defines a limited set of statically parameterized types and a common interface that is shared between them. Defining a new static type that conforms with this interface only requires defining the following:
+`Static` defines a set of types (`True`, `False`, `StaticInt{value::Int}`, `StaticFloat64{value::Float64}`, `StaticSymbol{value::Symbol}`) that may be dispatched on (similar to `Base.Val{value}`). Unlike `Base.Val`, instances of these types provide "static" values (meaning known at compile time) that in many cases work interchangeably with dynamic values (meaning the value is known at runtime but not compile time). This is particularly useful when designing types whose fields may be dynamically or statically known, such as a range whose size may be dynamic or statically known.
 
-* `Static.static(::T)` - given the non-static type `T` return its static counterpart.
-* `Static.is_static(::Type{S})` - given the static type `S` return `True()`.
-* `Static.known(::Type{S})`- given the static type `S` return the known non-static value.
-
-Fore example, the following would appropriately define the interface for `StaticChar`
+Generic conversion to static values, dynamic values, and compile time known values is accomplished with the methods `static`, `dynamic`, and `known`, respectively.
 
 ```julia
-Static.static(x::Char) = StaticChar(x)
-Static.is_static(::Type{T}) where {T<:StaticChar} = True()
-Static.known(::Type{StaticChar{C}}) where {C} = C::Char
+julia> using Static
+
+julia> static(1)
+static(1)
+
+julia> dynamic(static(1))
+1
+
+julia> dynamic(1)
+1
+
+julia> typeof(static(1))
+StaticInt{1}
+
+julia> known(typeof(static(1)))
+1
+
+julia> known(typeof(1)) === nothing  # `Int`  has no compile time known value
+true
+
 ```


### PR DESCRIPTION
My original attempt at the README was mostly intended to illustrate how we approached creating the types here, but there's a pretty compelling argument to be made that there shouldn't be anymore types that are explicitly static (such as the current `StaticChar` example).

This new README focuses more on basic definitions and using the types defined herein.