### PR TITLE
Define `zero(::StaticInt)`

### DIFF
--- a/src/Static.jl
+++ b/src/Static.jl
@@ -43,6 +43,8 @@ end
 
 Base.getindex(x::Tuple, ::StaticInt{N}) where {N} = getfield(x, N)
 
+Base.zero(@nospecialize(::StaticInt)) = StaticInt{0}()
+
 Base.to_index(x::StaticInt) = known(x)
 function Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, ::StaticNumber{N}) where {N}
     checkindex(Bool, inds, N)


### PR DESCRIPTION
The motivation is that we have this on Julia nightly:
```julia
julia> zero(static(9))
ERROR: TypeError: in typeassert, expected StaticInt{9}, got a value of type StaticInt{0}
Stacktrace:
 [1] convert
   @ ./number.jl:7 [inlined]
 [2] oftype(x::StaticInt{9}, y::Int64)
   @ Base ./essentials.jl:469
 [3] zero(x::StaticInt{9})
   @ Base ./number.jl:308
 [4] top-level scope
   @ REPL[11]:1
```
The type assert was added (versus Julia 1.8) because of invalidations.