### PR TITLE
Ensure inference never completely fails

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -187,14 +187,14 @@ _get_known(::Type{T}, dim::StaticInt{D}) where {T, D} = known(field_type(T, dim)
 known(@nospecialize(T::Type{<:Tuple})) = eachop(_get_known, nstatic(Val(fieldcount(T))), T)
 known(T::DataType) = nothing
 known(@nospecialize(T::Type{<:NDIndex})) = known(T.parameters[2])
-known(::Union{True,Type{True}}) = true
-known(::Union{False,Type{False}}) = false
-known(::Union{Val{V},Type{Val{V}}}) where {V} = V
-known(::Union{StaticInt{N},Type{StaticInt{N}}}) where {N} = _return_int(N)
+known(::Union{True, Type{True}}) = true
+known(::Union{False, Type{False}}) = false
+known(::Union{Val{V}, Type{Val{V}}}) where {V} = V
+known(::Union{StaticInt{N}, Type{StaticInt{N}}}) where {N} = _return_int(N)
 _return_int(x::Int) = x
-known(::Union{StaticSymbol{S},Type{StaticSymbol{S}}}) where {S} = _return_symbol(S)
+known(::Union{StaticSymbol{S}, Type{StaticSymbol{S}}}) where {S} = _return_symbol(S)
 _return_symbol(x::Symbol) = x
-known(::Union{StaticFloat64{F},Type{StaticFloat64{F}}}) where {F} = _return_float(F)
+known(::Union{StaticFloat64{F}, Type{StaticFloat64{F}}}) where {F} = _return_float(F)
 _return_float(x::Float64) = x
 
 """
@@ -281,7 +281,7 @@ julia> dynamic(1)
 @inline dynamic(@nospecialize x::StaticInt) = known(x)
 @inline dynamic(@nospecialize x::StaticFloat64) = known(x)
 @inline dynamic(@nospecialize x::StaticSymbol) = known(x)
-@inline dynamic(@nospecialize x::Union{True,False}) = known(x)
+@inline dynamic(@nospecialize x::Union{True, False}) = known(x)
 @inline dynamic(@nospecialize x::Tuple) = map(dynamic, x)
 dynamic(@nospecialize(x::NDIndex)) = CartesianIndex(dynamic(Tuple(x)))
 dynamic(@nospecialize x) = x

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -163,20 +163,39 @@ end
 Base.Tuple(@nospecialize(x::NDIndex)) = getfield(x, :index)
 
 """
-    known(::Type{T})
+    known(T::Type)
 
 Returns the known value corresponding to a static type `T`. If `T` is not a static type then
 `nothing` is returned.
 
-See also: [`static`](@ref), [`is_static`](@ref)
+`known` ensures that the type of the returned value is always inferred, even if the
+compiler fails to infer the exact value.
+
+See also: [`static`](@ref), [`is_static`](@ref), [`dynamic`](@ref)
+
+# Examples
+```julia
+julia> known(StaticInt{1})
+1
+
+julia> known(Int)
+
+```
 """
-known(::Type{<:StaticType{T}}) where {T} = T
-known(::Type{Val{V}}) where {V} = V
+known(@nospecialize(x)) = known(typeof(x))
 _get_known(::Type{T}, dim::StaticInt{D}) where {T, D} = known(field_type(T, dim))
 known(@nospecialize(T::Type{<:Tuple})) = eachop(_get_known, nstatic(Val(fieldcount(T))), T)
 known(T::DataType) = nothing
-known(@nospecialize(x)) = known(typeof(x))
 known(@nospecialize(T::Type{<:NDIndex})) = known(T.parameters[2])
+known(::Union{True,Type{True}}) = true
+known(::Union{False,Type{False}}) = false
+known(::Union{Val{V},Type{Val{V}}}) where {V} = V
+known(::Union{StaticInt{N},Type{StaticInt{N}}}) where {N} = _return_int(N)
+_return_int(x::Int) = x
+known(::Union{StaticSymbol{S},Type{StaticSymbol{S}}}) where {S} = _return_symbol(S)
+_return_symbol(x::Symbol) = x
+known(::Union{StaticFloat64{F},Type{StaticFloat64{F}}}) where {F} = _return_float(F)
+_return_float(x::Float64) = x
 
 """
     static(x)
@@ -185,6 +204,8 @@ Returns a static form of `x`. If `x` is already in a static form then `x` is ret
 there is no static alternative for `x` then an error is thrown.
 
 See also: [`is_static`](@ref), [`known`](@ref)
+
+# Examples
 
 ```julia
 julia> using Static
@@ -238,9 +259,29 @@ is_static(T::DataType) = False()
 """
     dynamic(x)
 
-Returns the "dynamic" or non-static form of `x`.
+Returns the "dynamic" or non-static form of `x`. If `x` is not a static type, then it is
+returned unchanged.
+
+`dynamic` ensures that the type of the returned value is always inferred, even if the
+compiler fails to infer the exact value.
+
+See also: [`known`](@ref)
+
+# Examples
+
+```julia
+julia> dynamic(static(1))
+1
+
+julia> dynamic(1)
+1
+
+```
 """
-@inline dynamic(@nospecialize x::StaticType) = known(x)
+@inline dynamic(@nospecialize x::StaticInt) = known(x)
+@inline dynamic(@nospecialize x::StaticFloat64) = known(x)
+@inline dynamic(@nospecialize x::StaticSymbol) = known(x)
+@inline dynamic(@nospecialize x::Union{True,False}) = known(x)
 @inline dynamic(@nospecialize x::Tuple) = map(dynamic, x)
 dynamic(@nospecialize(x::NDIndex)) = CartesianIndex(dynamic(Tuple(x)))
 dynamic(@nospecialize x) = x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,7 @@ end
     t = static(static(true))
     f = StaticBool(static(false))
 
+    @test @inferred(dynamic(t)) === @inferred(known(t)) === true
     @test StaticBool{true}() === t
     @test StaticBool{false}() === f
 
@@ -403,6 +404,8 @@ y = 1:10
 @test @inferred(maybe_static_length(y)) === 10
 
 @testset "StaticFloat64" begin
+    f = static(1.0)
+    @test @inferred(dynamic(f)) === @inferred(known(f)) === 1.0
     for i in -10:10
         for j in -10:10
             @test i + j == @inferred(Static.StaticInt(i)+Static.StaticFloat64(j)) ==


### PR DESCRIPTION
With the arrival of assumed effects in the latest versions of Julia, I've found that static types are either perfectly inferred or cannot be inferred at all. The result is often the difference between the compiler inferring "total" effects or no effects at all.

This PR passes all values lowered through `known` and `dynamic` through one of `_return_<int/symbol/float>` methods. This is done instead of a type assertion becuause it narrows down potentially dynamic calls to a clear dispatch pattern and inferred type since Julia currently doesn't enforce that the type call `T(x)` return's `T`.