### PR TITLE
Specialize mod for real arguments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.8.5"
+version = "0.8.6"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -450,6 +450,8 @@ Base.rem(::StaticNumber{X}, ::StaticNumber{Y}) where {X, Y} = static(rem(X, Y))
 Base.rem(x::Real, ::StaticInteger{Y}) where {Y} = rem(x, Y)
 Base.rem(::StaticInteger{X}, y::Real) where {X} = rem(X, y)
 Base.mod(::StaticNumber{X}, ::StaticNumber{Y}) where {X, Y} = static(mod(X, Y))
+Base.mod(x::Real, ::StaticNumber{Y}) where {Y} = mod(x, Y)
+Base.mod(::StaticNumber{X}, y::Real) where {X} = mod(X, y)
 
 Base.:(==)(::StaticNumber{X}, ::StaticNumber{Y}) where {X, Y} = ==(X, Y)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,13 @@ end
 
     @test real(static(3)) === static(3)
     @test imag(static(3)) === static(0)
+
+    @test mod(static(3), static(3)) === static(0)
+    @test mod(static(3), 3) == 0
+    @test mod(3, static(3)) == 0
+    @test mod(static(3), static(2)) === static(1)
+    @test mod(static(3), 2) == 1
+    @test mod(3, static(2)) == 1
 end
 
 @testset "StaticBool" begin


### PR DESCRIPTION
These methods were missing. After this,
```julia
julia> mod(static(2), 2)
0
```