### PR TITLE
Fix Aqua related testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 [compat]
 Aqua = "0.8.4"
 IfElse = "0.1"
-Test = "1.10"
+Test = "1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,9 @@ version = "0.8.9"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 
 [compat]
+Aqua = "0.8.4"
 IfElse = "0.1"
+Test = "1.10"
 julia = "1.6"
 
 [extras]

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -90,7 +90,7 @@ function Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, ::StaticNumber{N
     checkindex(Bool, inds, N)
 end
 function Base.checkindex(::Type{Bool}, inds::Base.IdentityUnitRange,
-                         ::StaticFloat64{N}) where {N}
+        ::StaticFloat64{N}) where {N}
     checkindex(Bool, inds.indices, N)
 end
 
@@ -338,13 +338,13 @@ static(1):static(2):static(9)
 ```
 """
 Base.@propagate_inbounds @inline function static_promote(x::AbstractUnitRange{<:Integer},
-                                                         y::AbstractUnitRange{<:Integer})
+        y::AbstractUnitRange{<:Integer})
     fst = static_promote(static_first(x), static_first(y))
     lst = static_promote(static_last(x), static_last(y))
     return OptionallyStaticUnitRange(fst, lst)
 end
 Base.@propagate_inbounds @inline function static_promote(x::AbstractRange{<:Integer},
-                                                         y::AbstractRange{<:Integer})
+        y::AbstractRange{<:Integer})
     fst = static_promote(static_first(x), static_first(y))
     stp = static_promote(static_step(x), static_step(y))
     lst = static_promote(static_last(x), static_last(y))
@@ -355,9 +355,9 @@ function static_promote(x::Base.Slice, y::Base.Slice)
 end
 
 Base.@propagate_inbounds function _promote_shape(a::Tuple{A, Vararg{Any}},
-                                                 b::Tuple{B, Vararg{Any}}) where {A, B}
+        b::Tuple{B, Vararg{Any}}) where {A, B}
     (static_promote(getfield(a, 1), getfield(b, 1)),
-     _promote_shape(Base.tail(a), Base.tail(b))...)
+        _promote_shape(Base.tail(a), Base.tail(b))...)
 end
 _promote_shape(::Tuple{}, ::Tuple{}) = ()
 Base.@propagate_inbounds function _promote_shape(::Tuple{}, b::Tuple{B}) where {B}
@@ -366,23 +366,24 @@ end
 Base.@propagate_inbounds function _promote_shape(a::Tuple{A}, ::Tuple{}) where {A}
     (static_promote(static(1), getfield(a, 1)),)
 end
-Base.@propagate_inbounds function Base.promote_shape(a::Tuple{Vararg{Union{Int, StaticInt}}
-                                                              },
-                                                     b::Tuple{Vararg{Union{Int, StaticInt}}
-                                                              })
+Base.@propagate_inbounds function Base.promote_shape(a::Tuple{
+            Vararg{Union{Int, StaticInt}},
+        },
+        b::Tuple{Vararg{Union{Int, StaticInt}}
+        })
     _promote_shape(a, b)
 end
 
 function Base.promote_rule(@nospecialize(T1::Type{<:StaticNumber}),
-                           @nospecialize(T2::Type{<:StaticNumber}))
+        @nospecialize(T2::Type{<:StaticNumber}))
     promote_rule(eltype(T1), eltype(T2))
 end
 function Base.promote_rule(::Type{<:Base.TwicePrecision{R}},
-                           @nospecialize(T::Type{<:StaticNumber})) where {R <: Number}
+        @nospecialize(T::Type{<:StaticNumber})) where {R <: Number}
     promote_rule(Base.TwicePrecision{R}, eltype(T))
 end
 function Base.promote_rule(@nospecialize(T1::Type{<:StaticNumber}),
-                           T2::Type{<:Union{Rational, AbstractFloat, Signed}})
+        T2::Type{<:Union{Rational, AbstractFloat, Signed}})
     promote_rule(T2, eltype(T1))
 end
 
@@ -422,8 +423,8 @@ end
 Base.Integer(@nospecialize(x::StaticInt)) = x
 (::Type{T})(x::StaticInteger) where {T <: Real} = T(known(x))
 function (@nospecialize(T::Type{<:StaticNumber}))(x::Union{AbstractFloat,
-                                                           AbstractIrrational, Integer,
-                                                           Rational})
+        AbstractIrrational, Integer,
+        Rational})
     static(convert(eltype(T), x))
 end
 
@@ -866,7 +867,7 @@ Base.@propagate_inbounds function Base.getindex(x::NDIndex{N, T}, i::Int)::Int w
     return Int(getfield(Tuple(x), i))
 end
 Base.@propagate_inbounds function Base.getindex(x::NDIndex{N, T},
-                                                i::StaticInt{I}) where {N, T, I}
+        i::StaticInt{I}) where {N, T, I}
     return getfield(Tuple(x), I)
 end
 
@@ -953,10 +954,10 @@ __icmp(x::Bool) = ifelse(x, 0, -1)
 end
 # But for arrays of CartesianIndex, we just skip the appropriate number of inds
 @inline function Base.to_indices(A, inds,
-                                 I::Tuple{AbstractArray{NDIndex{N, J}}, Vararg{Any}}) where {
-                                                                                             N,
-                                                                                             J
-                                                                                             }
+        I::Tuple{AbstractArray{NDIndex{N, J}}, Vararg{Any}}) where {
+        N,
+        J,
+    }
     _, indstail = Base.IteratorsMD.split(inds, Val(N))
     return (Base.to_index(A, I[1]), to_indices(A, indstail, Base.tail(I))...)
 end
@@ -965,7 +966,7 @@ function Base.show(io::IO, @nospecialize(x::Union{StaticNumber, StaticSymbol, ND
     show(io, MIME"text/plain"(), x)
 end
 function Base.show(io::IO, ::MIME"text/plain",
-                   @nospecialize(x::Union{StaticNumber, StaticSymbol}))
+        @nospecialize(x::Union{StaticNumber, StaticSymbol}))
     print(io, "static(" * repr(known(typeof(x))) * ")")
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Test
 @testset "Aqua" begin
     Aqua.test_ambiguities(Static, recursive = false)
     Aqua.test_deps_compat(Static)
+    Aqua.test_piracies(Static, broken = true)
     Aqua.test_project_extras(Static)
     Aqua.test_stale_deps(Static)
     Aqua.test_unbound_args(Static)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Static: Zero
 using Test
 
 @testset "Aqua" begin
+    Aqua.find_persistent_tasks_deps(Static)
     Aqua.test_ambiguities(Static, recursive = false)
     Aqua.test_deps_compat(Static)
     Aqua.test_piracies(Static, broken = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,14 @@ using Static, Aqua
 using Static: Zero
 using Test
 
-Aqua.test_all(Static, piracy = false)
+@testset "Aqua" begin
+    Aqua.test_ambiguities(Static, recursive = false)
+    Aqua.test_deps_compat(Static)
+    Aqua.test_project_extras(Static)
+    Aqua.test_stale_deps(Static)
+    Aqua.test_unbound_args(Static)
+    Aqua.test_undefined_exports(Static)
+end
 
 @testset "StaticSymbol" begin
     x = StaticSymbol(:x)


### PR DESCRIPTION
Right now all tests are failing because of the one line `Aqua.test_all(Static, piracy = false)`. I tried to look at what other SciML repos are doing to fix this but it would probably be best of @ChrisRackauckas or some other SciML expert ensures this PR goes about this correctly.
