### PR TITLE
Add another missing NamedTuple getindex method for StaticSymbol

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1,1.6]
+        julia-version: [1]
         os: [ubuntu-latest]
         package:
           - {user: JuliaArrays, repo: ArrayInterface.jl, group: ArrayInterface}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "0.8.9"
+version = "0.8.10"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 Aqua = "0.8.4"
 IfElse = "0.1"
 Test = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -82,6 +82,9 @@ Base.promote_rule(::Type{Bool}, T::Type{<:StaticNumber}) = promote_rule(Bool, el
 Base.getindex(x::Tuple, ::StaticInt{N}) where {N} = getfield(x, N)
 
 Base.getindex(x::NamedTuple, ::StaticSymbol{N}) where {N} = getfield(x, N)
+function Base.getindex(x::NamedTuple, symbols::NTuple{N, StaticSymbol}) where {N}
+    return x[map(known, symbols)]
+end
 
 Base.zero(@nospecialize(::StaticInt)) = StaticInt{0}()
 

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -82,7 +82,7 @@ Base.promote_rule(::Type{Bool}, T::Type{<:StaticNumber}) = promote_rule(Bool, el
 Base.getindex(x::Tuple, ::StaticInt{N}) where {N} = getfield(x, N)
 
 Base.getindex(x::NamedTuple, ::StaticSymbol{N}) where {N} = getfield(x, N)
-function Base.getindex(x::NamedTuple, symbols::NTuple{N, StaticSymbol}) where {N}
+function Base.getindex(x::NamedTuple, symbols::Tuple{StaticSymbol, Vararg{StaticSymbol}})
     return x[map(known, symbols)]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ Aqua.test_all(Static, piracy = false)
     @test @inferred(static(nothing)) === nothing
     nt = (x = :x, y = "y", z = 1)
     @test @inferred(getindex(nt, x)) == :x
+    @test @inferred(getindex(nt, (x, y))) == (x = :x, y = "y")
     @test_throws ErrorException static([])
 end
 


### PR DESCRIPTION
Fixes #124 .  This addresses the need to do

```julia
nt = (a=1, b=2, c=3)
nt[(static(:a), static(:b))]
```

This is a follow-up to https://github.com/SciML/Static.jl/issues/120 and https://github.com/SciML/Static.jl/pull/121.

As noted in https://github.com/SciML/Static.jl/pull/121, the Aqua tests currently fail, but the tests pass otherwise.