### PR TITLE
Remove static pointer arithmetic

### DIFF
--- a/src/Static.jl
+++ b/src/Static.jl
@@ -438,10 +438,6 @@ Base.:(*)(::StaticInteger{X}, ::StaticInteger{Y}) where {X, Y} = static(X * Y)
 Base.:(/)(::StaticInteger{X}, ::StaticInteger{Y}) where {X, Y} = static(X / Y)
 Base.:(-)(::StaticInteger{X}, ::StaticInteger{Y}) where {X, Y} = static(X - Y)
 Base.:(+)(::StaticInteger{X}, ::StaticInteger{Y}) where {X, Y} = static(X + Y)
-Base.:(-)(x::Ptr, ::StaticInt{N}) where {N} = x - N
-Base.:(-)(::StaticInt{N}, y::Ptr) where {N} = y - N
-Base.:(+)(x::Ptr, ::StaticInt{N}) where {N} = x + N
-Base.:(+)(::StaticInt{N}, y::Ptr) where {N} = y + N
 
 @generated Base.sqrt(::StaticNumber{N}) where {N} = :($(static(sqrt(N))))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,12 +108,6 @@ end
     @test isless(static(1), static(2))
 
     v = rand(3)
-    GC.@preserve v begin
-        p = pointer(v)
-        @test +(p, static(1)) == +(static(1), p) == +(p, 1)
-        @test -(p, static(1)) == -(static(1), p) == -(p, 1)
-    end
-
     @test real(static(3)) === static(3)
     @test imag(static(3)) === static(0)
 


### PR DESCRIPTION
This seems largely unused but invalidates. Might as well remove it?
