### PR TITLE
Add CommonWorldInvalidations world

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Aqua = "0.8.4"
 CommonWorldInvalidations = "1"
 IfElse = "0.1"
+PrecompileTools = "1"
 Test = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Aqua = "0.8.4"
+CommonWorldInvalidations = "1"
 IfElse = "0.1"
 Test = "1"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,12 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
+CommonWorldInvalidations = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Aqua = "0.8.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,17 +2,17 @@ using Static
 using Documenter
 
 makedocs(;
-         modules = [Static],
-         authors = "chriselrod, ChrisRackauckas, Tokazama",
-         repo = "https://github.com/SciML/Static.jl/blob/{commit}{path}#L{line}",
-         sitename = "Static.jl",
-         format = Documenter.HTML(;
-                                  prettyurls = get(ENV, "CI", "false") == "true",
-                                  canonical = "https://SciML.github.io/Static.jl",
-                                  assets = String[]),
-         pages = [
-             "Home" => "index.md",
-         ])
+    modules = [Static],
+    authors = "chriselrod, ChrisRackauckas, Tokazama",
+    repo = "https://github.com/SciML/Static.jl/blob/{commit}{path}#L{line}",
+    sitename = "Static.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://SciML.github.io/Static.jl",
+        assets = String[]),
+    pages = [
+        "Home" => "index.md"
+    ])
 
 deploydocs(;
-           repo = "github.com/SciML/Static.jl")
+    repo = "github.com/SciML/Static.jl")

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -5,6 +5,12 @@ import IfElse: ifelse
 export StaticInt, StaticFloat64, StaticSymbol, True, False, StaticBool, NDIndex
 export dynamic, is_static, known, static, static_promote
 
+import PrecompileTools: @recompile_invalidations
+
+@recompile_invalidations begin
+    import CommonWorldInvalidations
+end
+
 """
     StaticSymbol
 

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -375,7 +375,8 @@ end
 Base.@propagate_inbounds function _promote_shape(a::Tuple{A}, ::Tuple{}) where {A}
     (static_promote(static(1), getfield(a, 1)),)
 end
-Base.@propagate_inbounds function Base.promote_shape(a::Tuple{
+Base.@propagate_inbounds function Base.promote_shape(
+        a::Tuple{
             Vararg{Union{Int, StaticInt}},
         },
         b::Tuple{Vararg{Union{Int, StaticInt}}
@@ -961,8 +962,8 @@ end
 @inline function Base.to_indices(A, inds,
         I::Tuple{AbstractArray{NDIndex{N, J}}, Vararg{Any}}) where {
         N,
-        J,
-    }
+        J
+}
     _, indstail = Base.IteratorsMD.split(inds, Val(N))
     return (Base.to_index(A, I[1]), to_indices(A, indstail, Base.tail(I))...)
 end

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -13,7 +13,7 @@ struct OptionallyStaticUnitRange{F <: IntType, L <: IntType} <:
     stop::L
 
     function OptionallyStaticUnitRange(start::IntType,
-                                       stop::IntType)
+            stop::IntType)
         new{typeof(start), typeof(stop)}(start, stop)
     end
     function OptionallyStaticUnitRange(start, stop)
@@ -57,39 +57,39 @@ static(2):static(2):10
 ```
 """
 struct OptionallyStaticStepRange{F <: IntType, S <: IntType,
-                                 L <: IntType} <: OrdinalRange{Int, Int}
+    L <: IntType} <: OrdinalRange{Int, Int}
     start::F
     step::S
     stop::L
 
     global function _OptionallyStaticStepRange(@nospecialize(start::IntType),
-                                               @nospecialize(step::IntType),
-                                               @nospecialize(stop::IntType))
+            @nospecialize(step::IntType),
+            @nospecialize(stop::IntType))
         new{typeof(start), typeof(step), typeof(stop)}(start, step, stop)
     end
 end
 @noinline function OptionallyStaticStepRange(@nospecialize(start::IntType),
-                                             ::StaticInt{0},
-                                             @nospecialize(stop::IntType))
+        ::StaticInt{0},
+        @nospecialize(stop::IntType))
     throw(ArgumentError("step cannot be zero"))
 end
 # we don't need to check the `stop` if we know it acts like a unit range
 function OptionallyStaticStepRange(@nospecialize(start::IntType),
-                                   step::StaticInt{1},
-                                   @nospecialize(stop::IntType))
+        step::StaticInt{1},
+        @nospecialize(stop::IntType))
     _OptionallyStaticStepRange(start, step, stop)
 end
 function OptionallyStaticStepRange(@nospecialize(start::IntType),
-                                   @nospecialize(step::StaticInt),
-                                   @nospecialize(stop::IntType))
+        @nospecialize(step::StaticInt),
+        @nospecialize(stop::IntType))
     _OptionallyStaticStepRange(start, step, _steprange_last(start, step, stop))
 end
 function OptionallyStaticStepRange(start, step, stop)
     OptionallyStaticStepRange(IntType(start), IntType(step), IntType(stop))
 end
 function OptionallyStaticStepRange(@nospecialize(start::IntType),
-                                   step::Int,
-                                   @nospecialize(stop::IntType))
+        step::Int,
+        @nospecialize(stop::IntType))
     if step === 0
         throw(ArgumentError("step cannot be zero"))
     else
@@ -99,7 +99,7 @@ end
 OptionallyStaticStepRange(@nospecialize x::OptionallyStaticStepRange) = x
 function OptionallyStaticStepRange(x::AbstractRange)
     _OptionallyStaticStepRange(IntType(static_first(x)), IntType(static_step(x)),
-                               IntType(static_last(x)))
+        IntType(static_last(x)))
 end
 
 # to make StepRange constructor inlineable, so optimizer can see `step` value
@@ -107,8 +107,8 @@ end
     StaticInt(_steprange_last(Int(start), Int(step), Int(stop)))
 end
 @inline function _steprange_last(start::Union{StaticInt, Int},
-                                 step::Union{StaticInt, Int},
-                                 stop::Union{StaticInt, Int})
+        step::Union{StaticInt, Int},
+        stop::Union{StaticInt, Int})
     _steprange_last(Int(start), Int(step), Int(stop))
 end
 @inline function _steprange_last(start::Int, step::Int, stop::Int)
@@ -147,7 +147,7 @@ SOneTo(n::Int) = SOneTo{n}()
 Base.oneto(::StaticInt{N}) where {N} = SOneTo{N}()
 
 const OptionallyStaticRange{F, L} = Union{OptionallyStaticUnitRange{F, L},
-                                          OptionallyStaticStepRange{F, <:Any, L}}
+    OptionallyStaticStepRange{F, <:Any, L}}
 
 # these probide a generic method for extracting potentially static values.
 static_first(x::Base.OneTo) = StaticInt(1)
@@ -217,13 +217,13 @@ Base.isempty(r::OptionallyStaticUnitRange) = first(r) > last(r)
 end
 
 function Base.checkindex(::Type{Bool},
-                         ::SUnitRange{F1, L1},
-                         ::SUnitRange{F2, L2}) where {F1, L1, F2, L2}
+        ::SUnitRange{F1, L1},
+        ::SUnitRange{F2, L2}) where {F1, L1, F2, L2}
     (F1::Int <= F2::Int) && (L1::Int >= L2::Int)
 end
 
 function Base.getindex(r::OptionallyStaticUnitRange,
-                       s::AbstractUnitRange{<:Integer})
+        s::AbstractUnitRange{<:Integer})
     @boundscheck checkbounds(r, s)
     f = static_first(r)
     fnew = f - one(f)
@@ -299,11 +299,12 @@ end
 function Base.axes1(x::OptionallyStaticStepRange)
     OptionallyStaticUnitRange(StaticInt(1), length(x))
 end
-function Base.axes1(x::OptionallyStaticStepRange{StaticInt{F}, StaticInt{S}, StaticInt{L}}) where {
-                                                                                                   F,
-                                                                                                   S,
-                                                                                                   L
-                                                                                                   }
+function Base.axes1(x::OptionallyStaticStepRange{
+        StaticInt{F}, StaticInt{S}, StaticInt{L}}) where {
+        F,
+        S,
+        L
+}
     OptionallyStaticUnitRange(StaticInt(1), StaticInt(_range_length(F, S, L)))
 end
 Base.axes1(x::Base.Slice{<:OptionallyStaticUnitRange{One}}) = x.indices
@@ -347,25 +348,25 @@ function Base.Broadcast.axistype(_, r::OptionallyStaticUnitRange{StaticInt{1}})
     Base.OneTo(last(r))
 end
 function Base.Broadcast.axistype(r::OptionallyStaticUnitRange{StaticInt{1}},
-                                 ::OptionallyStaticUnitRange{StaticInt{1}})
+        ::OptionallyStaticUnitRange{StaticInt{1}})
     Base.OneTo(last(r))
 end
 function Base.similar(::Type{<:Array{T}},
-                      axes::Tuple{OptionallyStaticUnitRange{StaticInt{1}},
-                                  Vararg{
-                                         Union{Base.OneTo,
-                                               OptionallyStaticUnitRange{StaticInt{1}}}}}) where {
-                                                                                                  T
-                                                                                                  }
+        axes::Tuple{OptionallyStaticUnitRange{StaticInt{1}},
+            Vararg{
+                Union{Base.OneTo,
+                OptionallyStaticUnitRange{StaticInt{1}}}}}) where {
+        T
+}
     Array{T}(undef, map(last, axes))
 end
 function Base.similar(::Type{<:Array{T}},
-                      axes::Tuple{Base.OneTo, OptionallyStaticUnitRange{StaticInt{1}},
-                                  Vararg{
-                                         Union{Base.OneTo,
-                                               OptionallyStaticUnitRange{StaticInt{1}}}}}) where {
-                                                                                                  T
-                                                                                                  }
+        axes::Tuple{Base.OneTo, OptionallyStaticUnitRange{StaticInt{1}},
+            Vararg{
+                Union{Base.OneTo,
+                OptionallyStaticUnitRange{StaticInt{1}}}}}) where {
+        T
+}
     Array{T}(undef, map(last, axes))
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -42,11 +42,14 @@
     @test UnitRange{Int}(Static.OptionallyStaticUnitRange(static(1), static(10))) ===
           UnitRange(1, 10)
 
-    @test AbstractUnitRange{Int}(Static.OptionallyStaticUnitRange(static(1), static(10))) isa
+    @test AbstractUnitRange{Int}(Static.OptionallyStaticUnitRange(
+        static(1), static(10))) isa
           Static.OptionallyStaticUnitRange
-    @test AbstractUnitRange{UInt}(Static.OptionallyStaticUnitRange(static(1), static(10))) isa
+    @test AbstractUnitRange{UInt}(Static.OptionallyStaticUnitRange(
+        static(1), static(10))) isa
           Base.OneTo
-    @test AbstractUnitRange{UInt}(Static.OptionallyStaticUnitRange(static(2), static(10))) isa
+    @test AbstractUnitRange{UInt}(Static.OptionallyStaticUnitRange(
+        static(2), static(10))) isa
           UnitRange
 
     @test @inferred((static(1):static(10))[static(2):static(3)]) === static(2):static(3)
@@ -98,11 +101,11 @@ CI = CartesianIndices((static(1):static(2), static(1):static(2)))
 
     @test @inferred(length(Static.OptionallyStaticStepRange(static(1), 2, 10))) == 5
     @test @inferred(length(Static.OptionallyStaticStepRange(static(1), static(1),
-                                                            static(10)))) == 10
+        static(10)))) == 10
     @test @inferred(length(Static.OptionallyStaticStepRange(static(2), static(1),
-                                                            static(10)))) == 9
+        static(10)))) == 9
     @test @inferred(length(Static.OptionallyStaticStepRange(static(2), static(2),
-                                                            static(10)))) == 5
+        static(10)))) == 5
 end
 
 @test @inferred(getindex(static(1):10, Base.Slice(static(1):10))) === static(1):10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -365,11 +365,14 @@ end
     # inferred is Union{Int,Nothing}
     @test Static.find_first_eq(1, map(Int, y)) === 3
 
-    @testset "reduce_tup" begin for n in 2:16
-        x = ntuple(_ -> rand(Bool) ? rand() : (rand(Bool) ? rand(0x00:0x1f) : rand(0:31)),
-                   n)
-        @test @inferred(Static.reduce_tup(+, x)) ≈ reduce(+, x)
-    end end
+    @testset "reduce_tup" begin
+        for n in 2:16
+            x = ntuple(
+                _ -> rand(Bool) ? rand() : (rand(Bool) ? rand(0x00:0x1f) : rand(0:31)),
+                n)
+            @test @inferred(Static.reduce_tup(+, x)) ≈ reduce(+, x)
+        end
+    end
 end
 
 @testset "invperm" begin
@@ -527,14 +530,16 @@ y = 1:10
 
     @test @inferred(static(2.0)^2.0) === 2.0^2.0
 
-    @testset "trig" begin for f in [sin, cos, tan, asin, atan, acos, sinh, cosh, tanh,
-        asinh, atanh, exp, exp2,
-        exp10, expm1, log, log2, log10, log1p, exponent, sqrt, cbrt, sec, csc, cot, sech,
-        secd, csch, cscd, cotd, cosd, tand, asind, acosd, atand, acotd, sech, coth, asech,
-        acsch, deg2rad, mod2pi, sinpi, cospi]
-        @info "Testing $f(0.5)"
-        @test @inferred(f(static(0.5))) === static(f(0.5))
-    end end
+    @testset "trig" begin
+        for f in [sin, cos, tan, asin, atan, acos, sinh, cosh, tanh,
+            asinh, atanh, exp, exp2,
+            exp10, expm1, log, log2, log10, log1p, exponent, sqrt, cbrt, sec, csc, cot, sech,
+            secd, csch, cscd, cotd, cosd, tand, asind, acosd, atand, acotd, sech, coth, asech,
+            acsch, deg2rad, mod2pi, sinpi, cospi]
+            @info "Testing $f(0.5)"
+            @test @inferred(f(static(0.5))) === static(f(0.5))
+        end
+    end
     @test @inferred(asec(static(2.0))) === static(asec(2.0))
     @test @inferred(acsc(static(2.0))) === static(acsc(2.0))
     @test @inferred(acot(static(2.0))) === static(acot(2.0))


### PR DESCRIPTION
This makes this package invalidation-free and precompiles based on an earlier state which matches Symbolics and thus reduces/removed repeated invalidation handling. This shouldn't effect compile at all from where we were before, but it will change precompilation time as it moves it all to a shared moment.
