### PR TITLE
Restrict `any` and all` argument type bounds

### DIFF
--- a/src/Static.jl
+++ b/src/Static.jl
@@ -518,7 +518,7 @@ Base.:(!)(::True) = False()
 Base.:(!)(::False) = True()
 
 Base.all(::Tuple{True, Vararg{True}}) = true
-Base.all(::Tuple{Union{True,False}, Vararg{Union{True, False}}}) = false
+Base.all(::Tuple{Union{True, False}, Vararg{Union{True, False}}}) = false
 
 Base.any(::Tuple{False, Vararg{False}}) = false
 Base.any(::Tuple{Union{True, False}, Vararg{Union{True, False}}}) = true

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -517,9 +517,8 @@ Base.xor(x::Union{Integer, Missing}, ::StaticInteger{Y}) where {Y} = xor(x, Y)
 Base.:(!)(::True) = False()
 Base.:(!)(::False) = True()
 
-Base.all(::Tuple{Vararg{True}}) = true
-Base.all(::Tuple{Vararg{Union{True, False}}}) = false
-Base.all(::Tuple{False, Vararg{False}}) = false
+Base.all(::Tuple{True, Vararg{True}}) = true
+Base.all(::Tuple{Union{True,False}, Vararg{Union{True, False}}}) = false
 
 Base.any(::Tuple{False, Vararg{False}}) = false
 Base.any(::Tuple{Union{True, False}, Vararg{Union{True, False}}}) = true

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -521,9 +521,8 @@ Base.all(::Tuple{Vararg{True}}) = true
 Base.all(::Tuple{Vararg{Union{True, False}}}) = false
 Base.all(::Tuple{False, Vararg{False}}) = false
 
-Base.any(::Tuple{True, Vararg{True}}) = true
-Base.any(::Tuple{Vararg{Union{True, False}}}) = true
-Base.any(::Tuple{Vararg{False}}) = false
+Base.any(::Tuple{False, Vararg{False}}) = false
+Base.any(::Tuple{Union{True, False}, Vararg{Union{True, False}}}) = true
 
 Base.real(@nospecialize(x::StaticNumber)) = x
 Base.real(@nospecialize(T::Type{<:StaticNumber})) = eltype(T)

--- a/src/Static.jl
+++ b/src/Static.jl
@@ -519,9 +519,9 @@ Base.:(!)(::False) = True()
 
 Base.all(::Tuple{Vararg{True}}) = true
 Base.all(::Tuple{Vararg{Union{True, False}}}) = false
-Base.all(::Tuple{Vararg{False}}) = false
+Base.all(::Tuple{False, Vararg{False}}) = false
 
-Base.any(::Tuple{Vararg{True}}) = true
+Base.any(::Tuple{True, Vararg{True}}) = true
 Base.any(::Tuple{Vararg{Union{True, False}}}) = true
 Base.any(::Tuple{Vararg{False}}) = false
 


### PR DESCRIPTION
This PR closes #132. 

Behavior does not change with the current Julia release, and the ambiguity is resolved for the nightly release.

Changes the argument types for the `any` and `all` methods on tuples to not rely on julia base definining
`all(::Tuple{}) = true` and `any(::Tuple{}) = false`.

## Checklist

- [x] Appropriate tests were added (code already covered by tests)
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This is not an issue with the current Julia release, but it likely will be in the future.
