### PR TITLE
Remove Base.all / Base.any methods on tuples of True/False (#162)

### DIFF
--- a/src/Static.jl
+++ b/src/Static.jl
@@ -274,12 +274,10 @@ is_static(@nospecialize(x)) = is_static(typeof(x))
 is_static(@nospecialize(x::Type{<:StaticType})) = True()
 is_static(@nospecialize(x::Type{<:Val})) = True()
 _tuple_static(::Type{T}, i) where {T} = is_static(field_type(T, i))
+_all_static_flags(::Tuple{}) = True()
+_all_static_flags(t::Tuple) = first(t) === True() ? _all_static_flags(Base.tail(t)) : False()
 @inline function is_static(@nospecialize(T::Type{<:Tuple}))
-    if all(eachop(_tuple_static, nstatic(Val(fieldcount(T))), T))
-        return True()
-    else
-        return False()
-    end
+    return _all_static_flags(eachop(_tuple_static, nstatic(Val(fieldcount(T))), T))
 end
 is_static(T::DataType) = False()
 
@@ -575,12 +573,6 @@ Base.xor(x::Union{Integer, Missing}, ::StaticInteger{Y}) where {Y} = xor(x, Y)
 
 Base.:(!)(::True) = False()
 Base.:(!)(::False) = True()
-
-Base.all(::Tuple{True, Vararg{True}}) = true
-Base.all(::Tuple{Union{True, False}, Vararg{Union{True, False}}}) = false
-
-Base.any(::Tuple{False, Vararg{False}}) = false
-Base.any(::Tuple{Union{True, False}, Vararg{Union{True, False}}}) = true
 
 Base.real(@nospecialize(x::StaticNumber)) = x
 Base.real(@nospecialize(T::Type{<:StaticNumber})) = eltype(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,14 +216,6 @@ end
     @test_throws DivideError rem(t, f)
     @test @inferred(mod(t, t)) === f
 
-    @test @inferred(all((t, t, t)))
-    @test !@inferred(all((t, f, t)))
-    @test !@inferred(all((f, f, f)))
-
-    @test @inferred(any((t, t, t)))
-    @test @inferred(any((t, f, t)))
-    @test !@inferred(any((f, f, f)))
-
     @test static(true) == true
     @test static(false) != true
     @test static(true) != false


### PR DESCRIPTION
## Summary
Closes #162.

These methods at `src/Static.jl:579-583` extended `Base.all` and `Base.any` for tuples whose element types are `Static.True` / `Static.False`. Removing them is not as trivial as it looks — generic `Base.all` / `Base.any` falls through to `if v ... end` on each element, and `Static.True` / `Static.False` aren't implicitly Bool, so the generic path raises `TypeError: non-boolean (True/False) used in boolean context` for these tuples.

The only internal caller was `is_static(::Type{<:Tuple})`, which was using `all(eachop(_tuple_static, ...))`. Replaced with a small recursive helper `_all_static_flags` that short-circuits on the first `False()` and returns `True()` / `False()` directly without ever entering boolean context.

The `@inferred all((t,f,t))` / `any(...)` tests on lines 219-225 of `test/runtests.jl` were only exercising the removed methods (and would now hit the same `if v` Base issue), so they're dropped.

### Behavior change for downstream
Anyone calling `Base.all` / `Base.any` directly on a tuple of `Static.True` / `Static.False` (e.g. `all((True(), False()))`) will now get the same `TypeError` from Base. The fix on the caller side is to convert to `Bool` first or use a custom reducer. Worth noting in release notes for whatever Static version ships this.

## Test plan
Local `Pkg.test()` on Julia 1.10:
```
StaticInt        | 167 pass
StaticFloat64    | 1864 pass
StaticBool       | 95 pass     ← was 95 pass + 6 errored before this PR
static interface | 26 pass     ← was 24 pass + 2 errored before this PR
... (all groups pass)
     Testing Static tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)