### PR TITLE
ci: drop macOS-latest x64 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
           - x64


### PR DESCRIPTION
## Summary
GitHub's `macOS-latest` runner image is now Apple Silicon (`arm64`), so the existing `macOS-latest` + `arch: x64` combination in `.github/workflows/ci.yml` is testing an architecture that mainstream macOS users no longer run on. It either falls back to Rosetta translation or to a deprecated x86 runner pool — either way it's not a useful signal for the package, while still costing macOS-runner minutes.

Removing macOS from the OS matrix entirely; ubuntu and windows continue to cover x64. macOS-aarch64 can be added back as a separate matrix entry later if anyone wants real Apple Silicon coverage.

## Test plan
- [ ] CI on this PR runs only ubuntu and windows jobs (no macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)