### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,9 +14,8 @@ jobs:
   test:
     strategy:
       matrix:
-        julia-version: ['1.10']
+        julia-version: ['lts']
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Canonical CI cleanup

- Replaced the inlined `JuliaRegistries/TagBot` workflow with the canonical thin caller (`SciML/.github/.github/workflows/tagbot.yml@v1`). Single-package form; this repo is not a monorepo (no `lib/<Name>` subpackages).
- Downgrade caller: removed the `skip: "Pkg,TOML"` input (both are Julia stdlibs, now auto-populated by the centralized workflow) and moved the Julia floor to the `lts` alias.


Static verification only: edited YAML/TOML confirmed to parse. No instantiate/precompile/test run.

Ignore until reviewed by @ChrisRackauckas.