### PR TITLE
QA: resolve Base.Broadcast.axistype ambiguity with CommonWorldInvalidations

### DIFF
--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -379,10 +379,18 @@ end
     end
 end
 
-function Base.Broadcast.axistype(r::OptionallyStaticUnitRange{StaticInt{1}}, _)
+# The open argument is restricted to `AbstractUnitRange{<:Integer}` (the only thing a
+# broadcast axis ever is) rather than `Any`. A bare `::Any` slot here forms an
+# unresolvable diagonal ambiguity with despecialization methods such as
+# CommonWorldInvalidations' `axistype(::Any, ::AbstractUnitRange{Float64})`.
+function Base.Broadcast.axistype(
+        r::OptionallyStaticUnitRange{StaticInt{1}}, ::AbstractUnitRange{<:Integer}
+    )
     return Base.OneTo(last(r))
 end
-function Base.Broadcast.axistype(_, r::OptionallyStaticUnitRange{StaticInt{1}})
+function Base.Broadcast.axistype(
+        ::AbstractUnitRange{<:Integer}, r::OptionallyStaticUnitRange{StaticInt{1}}
+    )
     return Base.OneTo(last(r))
 end
 function Base.Broadcast.axistype(


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The master CI **QA** lane (both `julia 1` and `lts`) is red. `Aqua.test_ambiguities(Static; recursive=false)` reports **4 ambiguities**:

```
Ambiguity #1..4
axistype(::Any, ::CommonWorldInvalidations.UDespec{1,2,3,4})  @ CommonWorldInvalidations
axistype(r::OptionallyStaticUnitRange{StaticInt{1}}, ::Any)   @ Static  src/ranges.jl:382
```

## Root cause

`CommonWorldInvalidations` **v1.1.0** (picked up under Static's `[compat] CommonWorldInvalidations = "1"`; v1.0.0 had no such methods) ships despecialization methods

```julia
Base.Broadcast.axistype(::Any, ::UDespec_k)   # UDespec_k <: AbstractUnitRange{Float64}
```

Static's broadcast-axis helpers were declared with a bare `::Any` open slot:

```julia
axistype(r::OptionallyStaticUnitRange{StaticInt{1}}, _)
axistype(_, r::OptionallyStaticUnitRange{StaticInt{1}})
```

At the intersection `(OptionallyStaticUnitRange{StaticInt{1}}, UDespec_k)` neither method is more specific (Static wins the first arg, CWI wins the second) → an unresolvable diagonal ambiguity. The only method that resolves it is one referencing CWI's internal `UDespec` fixture types, which Static must not depend on.

## Fix

A broadcast axis is always an `AbstractUnitRange{<:Integer}` (axes carry integer indices; `Base.Broadcast.axistype` is only ever reached from `_bcs1(a, b)` with both args being array axes). Narrowing the open slot from `::Any` to `AbstractUnitRange{<:Integer}` keeps every real call dispatching to Static's methods while excluding CWI's `Float64`-eltype fixture types — removing the diagonal without naming CWI internals.

`OptionallyStaticUnitRange{StaticInt{1}}` is itself `<: AbstractUnitRange{<:Integer}`, so the existing 3-arg `(OSUR, OSUR)` disambiguator remains strictly more specific and unchanged.

## Verification (run locally)

- **QA green** on Julia **1.12** and **1.10 (lts)**: `Aqua` + `ExplicitImports` → `11 Pass, 1 Broken` (the pre-existing `test_piracies(broken=true)`), **0 Fail**. The 4 ambiguities are gone.
- **Core suite green**: `2615/2615` passing on Julia 1.12 (includes the `axistype` behavior tests in `test/shared/ranges.jl`).
- Confirmed the unmodified master reproduces the 4 ambiguities on lts, and the fix clears them on both channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)