### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -11,8 +9,6 @@ Static = { path = "../.." }
 
 [compat]
 Aqua = "0.8.4"
-ExplicitImports = "1.9"
-SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,18 +1,26 @@
-using Static, Aqua, ExplicitImports
-using Test
+using SciMLTesting, Static, Test
 
-@testset "Aqua" begin
-    Aqua.find_persistent_tasks_deps(Static)
-    Aqua.test_ambiguities(Static, recursive = false)
-    Aqua.test_deps_compat(Static)
-    Aqua.test_piracies(Static, broken = true)
-    Aqua.test_project_extras(Static)
-    Aqua.test_stale_deps(Static)
-    Aqua.test_unbound_args(Static)
-    Aqua.test_undefined_exports(Static)
-end
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(Static) === nothing
-    @test check_no_stale_explicit_imports(Static) === nothing
-end
+run_qa(
+    Static;
+    explicit_imports = true,
+    aqua_kwargs = (; ambiguities = (; recursive = false)),
+    # Aqua piracies: `Base.promote_shape` overload on `Tuple{Vararg{Union{Int,StaticInt}}}`
+    # subsumes plain `Tuple{Vararg{Int}}` — genuine Base piracy.
+    # Tracked in https://github.com/SciML/Static.jl/issues/181
+    aqua_broken = (:piracies,),
+    ei_kwargs = (;
+        # Base / Base.Broadcast / Base.IteratorsMD internals Static accesses but that
+        # are not (yet) declared public upstream; ignore until Base marks them public.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                Symbol("@propagate_inbounds"), :AbstractCartesianIndex, :Cartesian,
+                :Fix2, :IdentityUnitRange, :IteratorsMD, :OneTo, :Slice,
+                :TwicePrecision, :axes1, :axistype, :fptosi, :front, :isdone,
+                :issingletontype, :oneto, :setindex, :sitofp, :split, :tail,
+                :to_index, :to_shape,
+            ),
+        ),
+        # `ifelse` is exported-but-not-declared-public by IfElse.jl (its sole purpose).
+        all_explicit_imports_are_public = (; ignore = (:ifelse,)),
+    ),
+)


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts `test/qa/qa.jl` from the hand-rolled Aqua + ExplicitImports body to the SciMLTesting 1.6 `run_qa` form and enables the full ExplicitImports suite (`explicit_imports = true`).

## qa.jl
- Single `run_qa(Static; ...)` call. `Aqua.test_all` replaces the eight per-sub-check calls (`find_persistent_tasks_deps`, `test_ambiguities`, `test_deps_compat`, `test_piracies`, `test_project_extras`, `test_stale_deps`, `test_unbound_args`, `test_undefined_exports` — all covered by `test_all`).
- `Aqua.test_ambiguities(..., recursive = false)` preserved via `aqua_kwargs = (; ambiguities = (; recursive = false))`.
- `Aqua.test_piracies(..., broken = true)` mapped to `aqua_broken = (:piracies,)` (disables the sub-check in `test_all` + emits a tracked `@test_broken` placeholder).

## ExplicitImports findings (now all six checks run)
Previously only `no_implicit_imports` + `no_stale_explicit_imports` ran. Enabling all six:
- **Pass bare (4):** `no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`.
- **Ignored (2), other-package not-yet-public names:**
  - `all_qualified_accesses_are_public`: 22 `Base` / `Base.Broadcast` / `Base.IteratorsMD` internals (`@propagate_inbounds`, `tail`, `OneTo`, `axistype`, `to_index`, ...). Ignore until Base declares them public.
  - `all_explicit_imports_are_public`: `IfElse.ifelse` (exported-but-not-public by IfElse.jl, whose sole purpose is that name).
- **Broken (0), fixed (0).** No EI check is left failing or `@test_broken`.

## Aqua broken
- `piracies`: `Base.promote_shape` overload on `Tuple{Vararg{Union{Int,StaticInt}}}` subsumes plain `Tuple{Vararg{Int}}` — genuine Base piracy. Tracked in #181. (The earlier piracy issue #162, `Base.all`/`Base.any`, was a different, now-resolved method; #181 is the remaining one.)

## Deps (test/qa/Project.toml)
- Drop `ExplicitImports` and `SafeTestsets` (both transitive via SciMLTesting).
- Keep `Aqua` direct (the ambiguities child-process needs it as a direct dep).
- `SciMLTesting` compat -> `"1.6"`. No JET (it was not run before).

## Verification
Run locally against released SciMLTesting 1.6.0 (Pkg resolves 1.6.0; develop-by-path so master's #180 axistype fix is in scope), Julia 1.10 and 1.12:

```
Test Summary:     | Pass  Broken  Total   Time
Quality Assurance |   16       1     17
```

ExplicitImports nested set: 6/6 pass. 0 Fail / 0 Error; the single Broken is the tracked `aqua: piracies` placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)