### PR TITLE
Bump version to 1.4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.4.2 -> 1.4.3) to release unreleased commits on `master` via JuliaRegistrator.