### PR TITLE
Use SciMLTesting API docs QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,20 +13,18 @@ SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 AllocCheck = "0.1, 0.2"
 CommonWorldInvalidations = "1"
 IfElse = "0.1"
-Pkg = "1"
 PrecompileTools = "1.2.0"
 SafeTestsets = "0.1, 1"
 SciMLPublic = "1.0.0"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "Pkg", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["AllocCheck", "SafeTestsets", "SciMLTesting", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 AllocCheck = "0.1, 0.2"
 CommonWorldInvalidations = "1"
 IfElse = "0.1"
+Pkg = "1"
 PrecompileTools = "1.2.0"
 SafeTestsets = "0.1, 1"
 SciMLPublic = "1.0.0"
@@ -22,9 +23,10 @@ julia = "1.10"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["AllocCheck", "Pkg", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,13 +5,12 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[sources]
+Static = {path = "../.."}
+
 [compat]
 Aqua = "0.8.4"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
-
-[sources]
-SciMLTesting = { url = "https://github.com/SciML/SciMLTesting.jl", rev = "a5cecca928f2c684c23505c3cd83921d71753e2e" }
-Static = { path = "../.." }

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,11 +1,13 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8.4"
+SafeTestsets = "0.1, 1"
 SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -4,11 +4,12 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-Static = { path = "../.." }
-
 [compat]
 Aqua = "0.8.4"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
+
+[sources]
+SciMLTesting = { url = "https://github.com/SciML/SciMLTesting.jl", rev = "a5cecca928f2c684c23505c3cd83921d71753e2e" }
+Static = { path = "../.." }

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,9 +5,6 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-Static = {path = "../.."}
-
 [compat]
 Aqua = "0.8.4"
 SafeTestsets = "0.1, 1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,7 @@ using SciMLTesting, Static, Test
 
 run_qa(
     Static;
+    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     aqua_kwargs = (; ambiguities = (; recursive = false)),
     # Aqua piracies: `Base.promote_shape` overload on `Tuple{Vararg{Union{Int,StaticInt}}}`
@@ -24,20 +25,3 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:ifelse,)),
     ),
 )
-
-@testset "public API documentation coverage" begin
-    public_names = setdiff(names(Static; all = false), (:Static,))
-    documented_bindings = Docs.meta(Static)
-    missing_docstrings = sort!(
-        String[
-            String(name) for name in public_names
-                if !haskey(documented_bindings, Docs.Binding(Static, name))
-        ]
-    )
-
-    @test isempty(missing_docstrings)
-
-    docs_index = read(joinpath(pkgdir(Static), "docs", "src", "index.md"), String)
-    @test occursin("```@autodocs", docs_index)
-    @test occursin("Modules = [Static]", docs_index)
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,8 @@
+if get(ENV, "GROUP", "") == "QA"
+    import Pkg
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.instantiate()
+end
+
 using SciMLTesting
 run_tests()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,2 @@
-if get(ENV, "GROUP", "") == "QA"
-    import Pkg
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    Pkg.instantiate()
-end
-
 using SciMLTesting
 run_tests()


### PR DESCRIPTION
## Summary

Ignore until reviewed by @ChrisRackauckas.

Follow-up to #185, which was merged before the latest instruction to use SciMLTesting's built-in API-docs checker.

- Replace the hand-rolled public API docs `@testset` with `run_qa(...; api_docs_kwargs = (; rendered = true))`.
- Pin `test/qa/Project.toml` to SciMLTesting `2.1.0` from `SciML/SciMLTesting.jl@a5cecca928f2c684c23505c3cd83921d71753e2e`, since General currently resolves only 1.x.
- Activate the QA project before loading SciMLTesting when `GROUP=QA`, so the grouped-tests entrypoint loads the pinned SciMLTesting version instead of the root test dependency.
- Add `SafeTestsets` to the QA environment and `Pkg` to root test extras because the grouped test runner needs `SafeTestsets` after activating `test/qa`, and `test/runtests.jl` now imports `Pkg` during QA setup.

## Validation

- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 -e 'using Pkg; Pkg.activate(; temp=true); Pkg.add(PackageSpec(name="Runic", version="1")); using Runic; ...'` — Runic check passed for `test/runtests.jl` and `test/qa/qa.jl`.
- `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'` — CI-shaped QA `Pkg.test` passed with SciMLTesting `2.1.0` from the pinned commit.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/SciML/SciMLTesting.jl", rev="a5cecca928f2c684c23505c3cd83921d71753e2e")); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); using SciMLTesting; @assert isdefined(SciMLTesting, :run_api_docs); include("test/qa/qa.jl")'` — lts QA passed against the local checkout and pinned SciMLTesting commit.