### PR TITLE
Release prep: bump Static to 1.4.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Static"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["chriselrod", "ChrisRackauckas", "Tokazama"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test scaffolding changes since 1.4.3 (no functional/behavioral changes).