### PR TITLE
Use SciMLTesting 2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ IfElse = "0.1"
 PrecompileTools = "1.2.0"
 SafeTestsets = "0.1, 1"
 SciMLPublic = "1.0.0"
-SciMLTesting = "2.1"
+SciMLTesting = "2.2"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,6 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8.4"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.2"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
## Summary

Ignore until reviewed by @ChrisRackauckas.

- Updates the `SciMLTesting` compat bound from `2.1` to `2.2` in the package test extras and QA test environment.
- Leaves the existing SciMLTesting QA setup unchanged.

## Local verification

- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`
  - Result: passed. Output included `SciMLTesting v2.2.0` and `Test Summary: | Pass  Broken  Total   Time` / `QA/qa.jl      |   18       1     19  53.4s`, followed by `Testing Static tests passed`.
- `git diff --check`
  - Result: passed with no output.