### PR TITLE
Restore SciMLTesting 2.1 QA floor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ IfElse = "0.1"
 PrecompileTools = "1.2.0"
 SafeTestsets = "0.1, 1"
 SciMLPublic = "1.0.0"
-SciMLTesting = "2.2"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,6 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8.4"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.2"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
## Summary
- Restore `SciMLTesting` compat from `"2.2"` to `"2.1"` in `Project.toml` and `test/qa/Project.toml`.
- Keeps the QA floor compatible with SciMLTesting 2.1 while still allowing newer 2.x releases.

Ignore this PR until reviewed by @ChrisRackauckas.

## Validation
- `git diff --check` passed.
- Runic.jl `--check` passed from a temporary local workspace environment.
- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed: `QA/qa.jl | 18 pass, 1 broken, 19 total, 1m01.5s`; `Testing Static tests passed`.
- Exact floor smoke with `--project=test/qa` and forced `SciMLTesting@2.1.0` passed: `Pkg.status("SciMLTesting")` showed `SciMLTesting v2.1.0`; `Quality Assurance | 18 pass, 1 broken, 19 total, 42.2s`.
