### PR TITLE
Refresh direct downstream test targets

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -13,18 +13,12 @@ jobs:
       matrix:
         julia-version: [1]
         package:
-          - {user: JuliaArrays, repo: ArrayInterface.jl, group: ArrayInterface}
-          - {user: JuliaSIMD, repo: VectorizationBase.jl, group: Interface}
-          - {user: JuliaSIMD, repo: LoopVectorization.jl, group: Downstream3}
-          - {user: JuliaDiff, repo: SparseDiffTools.jl, group: Core}
-          - {user: SciML, repo: SciMLBase.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream2}
-          - {user: SciML, repo: DiffEqSensitivity.jl, group: Core}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Core}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface}
-          - {user: SciML, repo: DelayDiffEq.jl, group: Interface}
+          - {user: JuliaSIMD, repo: VectorizationBase.jl, group: All}
+          - {user: JuliaSIMD, repo: LoopVectorization.jl, group: All}
+          - {user: SciML, repo: FastBroadcast.jl, group: Core}
+          - {user: SciML, repo: DiffEqFlux.jl, group: All}
+          - {user: SciML, repo: DeepEquilibriumNetworks.jl, group: Core}
+          - {user: SciML, repo: ReservoirComputing.jl, group: All}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"


### PR DESCRIPTION
## Summary

- remove stale downstream rows for packages that no longer directly depend on Static or have moved into monorepos
- test the current direct dependents: VectorizationBase, LoopVectorization, FastBroadcast, DiffEqFlux, DeepEquilibriumNetworks, and ReservoirComputing
- use each target's actual test selection (`Core` where declared, otherwise the package's intentional full suite)

## Local verification

I rehearsed every proposed matrix row on Julia 1.12 after developing this Static checkout into the target environment. Every target manifest contained a path entry for the local Static package.

- VectorizationBase `All` — passed
- LoopVectorization `All` — passed
- FastBroadcast `Core` — passed
- DiffEqFlux `All` — passed; terminal output was `Testing DiffEqFlux tests passed` after exercising the full suite, including Neural DE 241/241, Neural ODE MM 1/1, CNF 27 pass with four pre-existing broken tests, Newton Neural ODE 4/4, Collocation 50/50, and Stiff Nested AD 3/3
- DeepEquilibriumNetworks `Core` — passed
- ReservoirComputing `All` — passed

The existing broken cases were not added, changed, skipped, or weakened by this PR.

Additional checks:

- `actionlint .github/workflows/Downstream.yml` — passed
- `julia +1.12 --startup-file=no -m Runic --check .` — passed
- `git diff --check` — passed

**Please ignore this draft until it has been reviewed by @ChrisRackauckas.**