### PR TITLE
Use standard SciMLTesting QA docs check

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, Static, Test
 
 run_qa(
     Static;
-    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     aqua_kwargs = (; ambiguities = (; recursive = false)),
     # Aqua piracies: `Base.promote_shape` overload on `Tuple{Vararg{Union{Int,StaticInt}}}`


### PR DESCRIPTION
Removes the repository-specific rendered API-docs override. Static already requires SciMLTesting `2.1+`; the standard QA configuration now owns this check.

Validated with Runic, the standard QA environment, and `Pkg.test()`.

Ignore until reviewed by @ChrisRackauckas.