### PR TITLE
Use SciMLTesting default QA checks

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,8 +2,6 @@ using SciMLTesting, Static, Test
 
 run_qa(
     Static;
-    api_docs_kwargs = (; rendered = true),
-    explicit_imports = true,
     aqua_kwargs = (; ambiguities = (; recursive = false)),
     # Aqua piracies: `Base.promote_shape` overload on `Tuple{Vararg{Union{Int,StaticInt}}}`
     # subsumes plain `Tuple{Vararg{Int}}` — genuine Base piracy.


### PR DESCRIPTION
Removes redundant rendered-public-doc and explicit-import QA settings. SciMLTesting 2.3 enables both checks by default; existing Aqua and ExplicitImports exceptions are unchanged.

Local verification: `Pkg.test()` completed with SciMLTesting 2.3.0; Runic check passed.

Ignore until reviewed by @ChrisRackauckas.