### PR TITLE
Fix widen(static(1)) assertion on 32-bit Julia

### DIFF
--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -93,7 +93,7 @@ end
     end
     @test @inferred(getindex([1], static(1))) == 1
     @test @inferred(Base.checkindex(Bool, 1:10, static(1)))
-    @test widen(static(1)) isa Int128
+    @test widen(static(1)) isa typeof(widen(1))
     @test isless(static(1), static(2))
 
     v = rand(3)


### PR DESCRIPTION
## Summary
- x86 CI failed with `widen(static(1)) isa Int128` (2614 passed, 1 failed)
- On 32-bit Julia, `widen(1)` is `Int64`, matching Static's `widen(::StaticNumber)` which delegates to `widen(known(x))`

## Test plan
- [ ] Ubuntu x86 Core lane green
- [ ] Existing x64 tests still pass


Made with [Cursor](https://cursor.com)