### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,49 @@
+using Static, BenchmarkTools
+using StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+x = rand(rng, 100)
+s3 = static(3)
+s_true = static(true)
+
+# =============================================================================
+# static / dynamic conversions and queries
+# =============================================================================
+
+SUITE["convert"] = BenchmarkGroup()
+
+SUITE["convert"]["static"] = @benchmarkable static(3)
+SUITE["convert"]["dynamic"] = @benchmarkable dynamic($s3)
+SUITE["convert"]["known"] = @benchmarkable known($s3)
+SUITE["convert"]["is_static"] = @benchmarkable is_static($s3)
+SUITE["convert"]["static_promote"] = @benchmarkable static_promote($s3, 3)
+
+# =============================================================================
+# Arithmetic on static values (compile-time specialization paths)
+# =============================================================================
+
+SUITE["arith"] = BenchmarkGroup()
+
+SUITE["arith"]["add"] = @benchmarkable $s3 + $s3
+SUITE["arith"]["mul"] = @benchmarkable $s3 * $s3
+
+SUITE["arith"]["lt"] = @benchmarkable $s3 < static(5)
+
+# =============================================================================
+# Static-bool logic
+# =============================================================================
+
+SUITE["logic"] = BenchmarkGroup()
+
+SUITE["logic"]["and"] = @benchmarkable $s_true & static(true)
+SUITE["logic"]["ifelse"] = @benchmarkable ifelse($s_true, 1, 2)
+
+# =============================================================================
+# NDIndex iteration
+# =============================================================================
+
+SUITE["ndindex"] = BenchmarkGroup()
+
+SUITE["ndindex"]["construct"] = @benchmarkable NDIndex(static(1), 2, static(3))


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~5s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~5s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md